### PR TITLE
Implement background removal of deleted dreams from default playlists

### DIFF
--- a/src/controllers/dream.controller.ts
+++ b/src/controllers/dream.controller.ts
@@ -1436,6 +1436,13 @@ export const handleDeleteDream = async (
       return handleNotFound(req as RequestType, res);
     }
 
+    setImmediate(async () => {
+      const { removeDeletedDreamFromDefaultPlaylists } = await import(
+        "utils/default-playlist.util"
+      );
+      await removeDeletedDreamFromDefaultPlaylists(uuid);
+    });
+
     return res.status(httpStatus.OK).json(jsonResponse({ success: true }));
   } catch (err) {
     const error = err as Error;

--- a/src/utils/client.util.ts
+++ b/src/utils/client.util.ts
@@ -1,6 +1,6 @@
 import appDataSource from "database/app-data-source";
 import { Dream, Playlist, PlaylistItem } from "entities";
-import { In } from "typeorm";
+import { In, IsNull } from "typeorm";
 import {
   ClientDream,
   ClientPlaylist,
@@ -90,14 +90,17 @@ export const populateDefautPlaylist = async (
   }
 
   const dreams = await dreamRepository.find({
-    where: { uuid: In(uuids) },
+    where: {
+      uuid: In(uuids),
+      deleted_at: IsNull(),
+    },
     relations: { user: true, playlistItems: true },
     select: ["uuid", "updated_at"],
   });
 
-  const orderedDreams = uuids.map(
-    (uuid) => dreams.find((d) => uuid == d.uuid)!,
-  );
+  const orderedDreams = uuids
+    .map((uuid) => dreams.find((d) => uuid === d.uuid))
+    .filter((dream): dream is Dream => dream !== undefined);
 
   const clientDreams: PartialClientDream[] = orderedDreams.map((dream) => ({
     uuid: dream.uuid,

--- a/src/utils/default-playlist.util.ts
+++ b/src/utils/default-playlist.util.ts
@@ -151,3 +151,40 @@ export const computeAllUsersDefaultPlaylist = async () => {
     }
   }
 };
+
+/**
+ * Removes a deleted dream UUID from all default playlists
+ * This should be called when a dream is deleted to maintain data consistency
+ * @param dreamUuid - UUID of the deleted dream
+ * @returns void
+ */
+export const removeDeletedDreamFromDefaultPlaylists = async (
+  dreamUuid: string,
+) => {
+  try {
+    // Find all default playlists that contain this dream UUID
+    const defaultPlaylists = await defaultPlaylistRepository.find();
+
+    const playlistsToUpdate: DefaultPlaylist[] = [];
+
+    for (const playlist of defaultPlaylists) {
+      if (playlist.data && playlist.data.includes(dreamUuid)) {
+        playlist.data = playlist.data.filter((uuid) => uuid !== dreamUuid);
+        playlistsToUpdate.push(playlist);
+      }
+    }
+
+    if (playlistsToUpdate.length > 0) {
+      await defaultPlaylistRepository.save(playlistsToUpdate);
+      console.log(
+        `Removed dream ${dreamUuid} from ${playlistsToUpdate.length} default playlists`,
+      );
+    }
+  } catch (error) {
+    console.error(
+      `Error removing deleted dream ${dreamUuid} from default playlists:`,
+      error,
+    );
+    // Don't throw the error to avoid disrupting the main deletion flow
+  }
+};

--- a/src/utils/playlist.util.ts
+++ b/src/utils/playlist.util.ts
@@ -10,6 +10,7 @@ import {
   FindOptionsRelations,
   FindOptionsWhere,
   In,
+  IsNull,
 } from "typeorm";
 import { getUserSelectedColumns } from "./user.util";
 import appDataSource from "database/app-data-source";
@@ -383,7 +384,10 @@ export const populateDefautPlaylist = async (
   }
 
   const dreams = await dreamRepository.find({
-    where: { uuid: In(uuids) },
+    where: {
+      uuid: In(uuids),
+      deleted_at: IsNull(),
+    },
     relations: { user: true, startKeyframe: true, endKeyframe: true },
     select: {
       id: true,


### PR DESCRIPTION
- Added a new utility function to remove deleted dream UUIDs from all default playlists to maintain data consistency.
- Updated the dream deletion handler to call this function asynchronously after a dream is deleted.
- Modified queries in the playlist utilities to exclude soft-deleted dreams.