### PR TITLE
Fill user quota on playlist play

### DIFF
--- a/src/constants/user.constants.ts
+++ b/src/constants/user.constants.ts
@@ -9,6 +9,11 @@ export const NEW_USER_DEFAULT_QUOTA = 10 * 1024 * 1024 * 1024;
 export const DAILY_USER_DEFAULT_QUOTA = 1 * 1024 * 1024 * 1024;
 
 /**
+ * quota granted when a user starts interactive playback (e.g. plays a playlist)
+ */
+export const INTERACTIVE_QUOTA = 1 * 1024 * 1024 * 1024;
+
+/**
  * min user quouta is 0
  */
 export const MIN_USER_QUOTA = 0;

--- a/src/socket/remote-control.ts
+++ b/src/socket/remote-control.ts
@@ -21,7 +21,11 @@ import {
   setUserCurrentDream,
   setUserCurrentPlaylist,
 } from "utils/socket.util";
-import { setUserLastClientPingAt } from "utils/user.util";
+import {
+  fillUserInteractiveQuota,
+  getNextQuotaResetAt,
+  setUserLastClientPingAt,
+} from "utils/user.util";
 
 const NEW_REMOTE_CONTROL_EVENT = "new_remote_control_event";
 const PING_EVENT = "ping";
@@ -30,6 +34,7 @@ const GOOD_BYE_EVENT = "goodbye";
 const CLIENT_PRESENCE_EVENT = "client_presence";
 const WEB_CLIENT_STATUS_EVENT = "web_client_status";
 const STATE_SYNC_EVENT = "state_sync";
+const QUOTA_UPDATE_EVENT = "quota_update";
 const JOIN_DREAM_ROOM_EVENT = "join_dream_room";
 const LEAVE_DREAM_ROOM_EVENT = "leave_dream_room";
 
@@ -336,6 +341,15 @@ export const handleNewControlEvent = ({
           playlist_uuid: playlist.uuid,
         },
       );
+
+      // Fill quota to INTERACTIVE_QUOTA and notify the client
+      const newQuota = await fillUserInteractiveQuota(user);
+      const quotaPayload = {
+        quota: Number(newQuota),
+        quotaExpiresAt: getNextQuotaResetAt().toISOString(),
+      };
+      socket.emit(QUOTA_UPDATE_EVENT, quotaPayload);
+      socket.broadcast.to(roomId).emit(QUOTA_UPDATE_EVENT, quotaPayload);
 
       data = { ...data, name: playlist?.name };
     }

--- a/src/utils/user.util.ts
+++ b/src/utils/user.util.ts
@@ -11,6 +11,7 @@ import { Role } from "entities/Role.entity";
 import {
   DAILY_USER_DEFAULT_QUOTA,
   DAILY_USER_QUOTA_RESET_UTC_HOUR,
+  INTERACTIVE_QUOTA,
   MIN_USER_QUOTA,
 } from "constants/user.constants";
 import {
@@ -231,6 +232,21 @@ export const getNextQuotaResetAt = (now: Date = new Date()): Date => {
  * @param quotaToReduce amount by which to reduce the user's quota
  * @returns void
  */
+
+/**
+ * Fills a user's quota up to INTERACTIVE_QUOTA if it is currently below that.
+ * Returns the resulting quota value.
+ */
+export const fillUserInteractiveQuota = async (
+  user: User,
+): Promise<bigint | number> => {
+  const currentQuota = user.quota ?? MIN_USER_QUOTA;
+  if (currentQuota < INTERACTIVE_QUOTA) {
+    await userRepository.update(user.id, { quota: INTERACTIVE_QUOTA });
+    return INTERACTIVE_QUOTA;
+  }
+  return currentQuota;
+};
 
 export const reduceUserQuota = async (user: User, quotaToReduce: number) => {
   // ensures that the user's quota can't be negative


### PR DESCRIPTION
## Summary
- Adds `INTERACTIVE_QUOTA` constant (1GB), separate from `DAILY_USER_DEFAULT_QUOTA` so it can be tuned independently
- When a user plays a playlist via websocket, fills their quota up to `INTERACTIVE_QUOTA` if below
- Emits a new `quota_update` websocket event to all connected clients with the updated quota and expiration

## Test plan
- [ ] Play a playlist when user quota is below 1GB — verify quota is set to 1GB in DB
- [ ] Play a playlist when user quota is above 1GB — verify quota is unchanged
- [ ] Verify connected clients receive `quota_update` event with correct payload
- [ ] Run existing tests to check for regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)