### PR TITLE
Fix stale quota check in fillUserInteractiveQuota

### DIFF
--- a/src/utils/user.util.ts
+++ b/src/utils/user.util.ts
@@ -240,24 +240,28 @@ export const getNextQuotaResetAt = (now: Date = new Date()): Date => {
 export const fillUserInteractiveQuota = async (
   user: User,
 ): Promise<bigint | number> => {
-  const currentQuota = user.quota ?? MIN_USER_QUOTA;
-  console.log(
-    `fillUserInteractiveQuota: user.id=${user.id}, user.uuid=${
-      user.uuid
-    }, currentQuota=${currentQuota}, INTERACTIVE_QUOTA=${INTERACTIVE_QUOTA}, willUpdate=${
-      currentQuota < INTERACTIVE_QUOTA
-    }`,
-  );
-  if (currentQuota < INTERACTIVE_QUOTA) {
-    const result = await userRepository.update(user.id, {
+  // Use conditional DB update to avoid overwriting a quota that's already higher.
+  // We can't trust user.quota here because socket.data.user is stale from connection time.
+  const result = await userRepository
+    .createQueryBuilder()
+    .update(User)
+    .set({ quota: INTERACTIVE_QUOTA })
+    .where("id = :id AND quota < :quota", {
+      id: user.id,
       quota: INTERACTIVE_QUOTA,
-    });
+    })
+    .execute();
+
+  if (result.affected && result.affected > 0) {
     console.log(
-      `fillUserInteractiveQuota: update result affected=${result.affected}`,
+      `fillUserInteractiveQuota: user ${user.uuid} quota filled to ${INTERACTIVE_QUOTA}`,
     );
     return INTERACTIVE_QUOTA;
   }
-  return currentQuota;
+
+  // Quota was already >= INTERACTIVE_QUOTA, fetch current value from DB
+  const freshUser = await userRepository.findOne({ where: { id: user.id } });
+  return freshUser?.quota ?? INTERACTIVE_QUOTA;
 };
 
 export const reduceUserQuota = async (user: User, quotaToReduce: number) => {


### PR DESCRIPTION
## Summary
- Uses a conditional SQL update (`WHERE quota < INTERACTIVE_QUOTA`) instead of checking the stale `socket.data.user.quota` value in JS
- Only fills quota to 1GB when the DB value is actually below it — won't overwrite a higher quota
- Fetches fresh quota from DB when no update was needed, so the emitted `quota_update` value is accurate

## Context
The previous implementation used `user.quota` from `socket.data.user`, which is loaded once at connection time and never refreshed. If a user connected with low quota then had it increased (e.g. by admin or daily reset), playing a playlist would overwrite the higher value back down to 1GB.

## Test plan
- [ ] Set user quota to 2GB, play playlist — verify quota stays at 2GB
- [ ] Set user quota to 0.5GB, play playlist — verify quota is filled to 1GB
- [ ] Verify `quota_update` websocket event reflects the correct final quota in both cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)