### PR TITLE
fix: sync WorkOS role to database on login

### DIFF
--- a/src/utils/workos.util.ts
+++ b/src/utils/workos.util.ts
@@ -8,6 +8,8 @@ import httpStatus from "http-status";
 import { AUTH_MESSAGES } from "constants/messages/auth.constant";
 import type { SessionCookieData, User as WorkOSUser } from "@workos-inc/node";
 import { APP_LOGGER } from "shared/logger";
+import { roleRepository, userRepository } from "database/repositories";
+import { RoleType } from "types/role.types";
 
 const IS_DEVELOPMENT = env.NODE_ENV === "development";
 
@@ -127,6 +129,17 @@ export const setWorkOSUserContext = async (
     });
   const workOSRole = organizationMemberships.data[0]?.role.slug;
   const user = await syncWorkOSUser(workOSUser);
+
+  // Sync role from WorkOS if it differs from the database role
+  if (workOSRole && user.role?.name !== workOSRole) {
+    const matchedRole = await roleRepository.findOneBy({
+      name: workOSRole as RoleType,
+    });
+    if (matchedRole) {
+      await userRepository.update(user.id, { role: matchedRole });
+      user.role = matchedRole;
+    }
+  }
 
   res.locals.workosUser = workOSUser;
   res.locals.userRole = workOSRole;


### PR DESCRIPTION
## Summary
- Syncs the user's WorkOS organization role to the database on every authenticated request in `setWorkOSUserContext()`
- Previously, roles were only set during signup (via invite code) or through WorkOS webhooks — if a role was changed in WorkOS and the webhook failed or wasn't configured, the DB role stayed stale
- This makes role sync self-healing: any role change in WorkOS takes effect on the user's next login

## Test plan
- [ ] Change a user's role in WorkOS dashboard (e.g. user-group → admin-group)
- [ ] Have the user log in and verify `/v2/auth/authenticate` returns the updated role
- [ ] Verify the user can access role-gated routes (e.g. /studio for creator-group/admin-group)
- [ ] Verify that if the WorkOS role slug doesn't match any DB role, the user's existing role is preserved (no downgrade)

🤖 Generated with [Claude Code](https://claude.com/claude-code)