### PR TITLE
feat(auth): add machine-readable errorCode to refresh endpoint failure responses

### DIFF
--- a/src/constants/messages/auth.constant.ts
+++ b/src/constants/messages/auth.constant.ts
@@ -32,3 +32,26 @@ export const AUTH_MESSAGES = {
 export const SOCKET_AUTH_ERROR_MESSAGES = {
   UNAUTHORIZED: "UNAUTHORIZED",
 };
+
+/**
+ * Machine-readable error codes for auth failures.
+ *
+ * Returned as `errorCode` in 400 responses from the refresh endpoint so that
+ * clients can react programmatically without string-matching human-readable
+ * messages. Each value maps to a specific WorkOS `RefreshSessionFailureReason`
+ * (or to the generic UNKNOWN sentinel for unexpected states).
+ */
+export const AUTH_ERROR_CODES = {
+  /** The session has expired or been revoked (WorkOS: INVALID_GRANT). */
+  SESSION_EXPIRED: "SESSION_EXPIRED",
+  /** The session cookie is present but corrupt or tampered (WorkOS: INVALID_SESSION_COOKIE). */
+  SESSION_INVALID: "SESSION_INVALID",
+  /** No session cookie was included in the request (WorkOS: NO_SESSION_COOKIE_PROVIDED). */
+  NO_SESSION: "NO_SESSION",
+  /** The user must complete MFA enrolment before the session can be refreshed (WorkOS: MFA_ENROLLMENT). */
+  MFA_ENROLLMENT_REQUIRED: "MFA_ENROLLMENT_REQUIRED",
+  /** The user's organisation requires SSO; the current session cannot be refreshed (WorkOS: SSO_REQUIRED). */
+  SSO_REQUIRED: "SSO_REQUIRED",
+  /** An unexpected failure reason was returned; clients should treat this as a transient error. */
+  UNKNOWN: "UNKNOWN",
+} as const;

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -8,7 +8,7 @@ import {
   UserAttributes,
 } from "constants/aws/cognito.constant";
 import passport from "passport";
-import { AUTH_MESSAGES } from "constants/messages/auth.constant";
+import { AUTH_ERROR_CODES, AUTH_MESSAGES } from "constants/messages/auth.constant";
 import httpStatus from "http-status";
 import {
   ConfirmUserLoginWithCodeCredentials,
@@ -1140,22 +1140,49 @@ export const refreshWorkOS = async (req: RequestType, res: ResponseType) => {
     } else if (!authenticated && refreshResponse?.reason) {
       const reason = refreshResponse?.reason ?? "";
 
-      let message = AUTH_MESSAGES.EXPIRED_TOKEN;
-      if (reason === RefreshSessionFailureReason.NO_SESSION_COOKIE_PROVIDED) {
-        message = AUTH_MESSAGES.INVALID_TOKEN;
+      // Map every known WorkOS RefreshSessionFailureReason to a human-readable
+      // message and a stable machine-readable errorCode.  Clients should branch
+      // on errorCode rather than parsing the message string.
+      let message  = AUTH_MESSAGES.EXPIRED_TOKEN;
+      let errorCode = AUTH_ERROR_CODES.SESSION_EXPIRED;
+
+      if (reason === RefreshSessionFailureReason.INVALID_GRANT) {
+        // Most common case: the session has expired or been revoked.
+        message   = AUTH_MESSAGES.EXPIRED_TOKEN;
+        errorCode = AUTH_ERROR_CODES.SESSION_EXPIRED;
+      } else if (reason === RefreshSessionFailureReason.INVALID_SESSION_COOKIE) {
+        // The token is present but corrupt or tampered.
+        message   = AUTH_MESSAGES.INVALID_TOKEN;
+        errorCode = AUTH_ERROR_CODES.SESSION_INVALID;
+      } else if (reason === RefreshSessionFailureReason.NO_SESSION_COOKIE_PROVIDED) {
+        // No cookie was sent — client-side bug.
+        message   = AUTH_MESSAGES.INVALID_TOKEN;
+        errorCode = AUTH_ERROR_CODES.NO_SESSION;
+      } else if (reason === RefreshSessionFailureReason.MFA_ENROLLMENT) {
+        // User must complete MFA enrolment; direct them to the auth flow.
+        message   = AUTH_MESSAGES.AUTHENTICATION_FAILED;
+        errorCode = AUTH_ERROR_CODES.MFA_ENROLLMENT_REQUIRED;
+      } else if (reason === RefreshSessionFailureReason.SSO_REQUIRED) {
+        // Organisation enforces SSO; the current session cannot be refreshed.
+        message   = AUTH_MESSAGES.AUTHENTICATION_FAILED;
+        errorCode = AUTH_ERROR_CODES.SSO_REQUIRED;
       }
 
       return res.status(httpStatus.BAD_REQUEST).json(
         jsonResponse({
           success: false,
           message,
+          errorCode,
         }),
       );
     }
 
+    // Authenticated is false but no reason was provided — unexpected WorkOS state.
     return res.status(httpStatus.BAD_REQUEST).json(
       jsonResponse({
         success: false,
+        message: AUTH_MESSAGES.UNEXPECTED_ERROR,
+        errorCode: AUTH_ERROR_CODES.UNKNOWN,
       }),
     );
   } catch (error) {

--- a/src/routes/v2/auth.routes.ts
+++ b/src/routes/v2/auth.routes.ts
@@ -238,11 +238,27 @@ authRouter.get("/logout", requireAuth, authController.logout);
  *                data:
  *                  $ref: '#/components/schemas/Tokens'
  *      '400':
- *        description: Bad request
+ *        description: |
+ *          Session could not be refreshed. The `errorCode` field contains a
+ *          machine-readable reason that clients should branch on rather than
+ *          parsing the human-readable `message` string.
+ *          Possible errorCode values:
+ *            SESSION_EXPIRED           – session has expired or been revoked
+ *            SESSION_INVALID           – cookie is present but corrupt/tampered
+ *            NO_SESSION                – no session cookie was sent
+ *            MFA_ENROLLMENT_REQUIRED   – user must complete MFA enrolment
+ *            SSO_REQUIRED              – organisation requires SSO login
+ *            UNKNOWN                   – unexpected state; treat as transient
  *        content:
  *          application/json:
  *            schema:
- *              $ref: '#/components/schemas/BadApiResponse'
+ *              allOf:
+ *                - $ref: '#/components/schemas/BadApiResponse'
+ *                - type: object
+ *                  properties:
+ *                    errorCode:
+ *                      type: string
+ *                      example: SESSION_EXPIRED
  */
 authRouter.post("/refresh", authController.refreshWorkOS);
 

--- a/src/types/responses.types.ts
+++ b/src/types/responses.types.ts
@@ -2,4 +2,5 @@ export type JsonResponse = {
   success: boolean;
   message?: string;
   data?: object;
+  errorCode?: string;
 };


### PR DESCRIPTION
## Problem

The `POST /v2/auth/refresh` endpoint currently returns only a human-readable `message` string on failure. Every 400 response looks structurally identical to a client, making it impossible to programmatically distinguish between meaningfully different failure states:

| WorkOS reason | What it means | Correct client response |
|---|---|---|
| `INVALID_GRANT` | Session expired or revoked | Wipe session, prompt re-login |
| `INVALID_SESSION_COOKIE` | Token corrupt or tampered | Wipe session, prompt re-login |
| `NO_SESSION_COOKIE_PROVIDED` | Client sent no cookie at all | Client-side bug, don't wipe |
| `MFA_ENROLLMENT` | User must complete MFA enrolment | Redirect to MFA flow |
| `SSO_REQUIRED` | Organisation requires SSO | Redirect to SSO flow |

Without a machine-readable signal, clients must either treat all failures identically (losing important UX distinctions) or fragile-match on human-readable message strings that may change.

## What this PR does

Adds a stable `errorCode` string field to every 400 response from the refresh endpoint, mapping each `RefreshSessionFailureReason` from the WorkOS SDK to a named constant:

```
SESSION_EXPIRED          ← INVALID_GRANT
SESSION_INVALID          ← INVALID_SESSION_COOKIE
NO_SESSION               ← NO_SESSION_COOKIE_PROVIDED
MFA_ENROLLMENT_REQUIRED  ← MFA_ENROLLMENT
SSO_REQUIRED             ← SSO_REQUIRED
UNKNOWN                  ← unexpected / no reason provided
```

The `errorCode` constants are defined in `auth.constant.ts` alongside the existing `AUTH_MESSAGES`, and the `JsonResponse` type is extended with an optional `errorCode?: string` field (backward-compatible — only the refresh failure path sets it for now).

The Swagger spec for the 400 response is updated to document the field and enumerate the possible values.

## Why now

This was motivated by debugging the Linux client (PR #525 on the client repo). All refresh failures were being handled identically: the client wiped the stored session and told the user to re-login, regardless of the actual reason. With `MFA_ENROLLMENT_REQUIRED` and `SSO_REQUIRED` in particular, wiping the session is actively wrong — the session itself is fine, the user just needs to take an additional action.

The fix on the client side (checking `errorCode` in the 400 body) is straightforward once this field exists.

## Changes

| File | Change |
|---|---|
| `src/types/responses.types.ts` | Add `errorCode?: string` to `JsonResponse` |
| `src/constants/messages/auth.constant.ts` | Add `AUTH_ERROR_CODES` constant object |
| `src/controllers/auth.controller.ts` | Map all `RefreshSessionFailureReason` values to `errorCode`; handle the no-reason fallback path (previously returned an empty body) |
| `src/routes/v2/auth.routes.ts` | Document `errorCode` in the Swagger 400 schema |

## Backward compatibility

Purely additive. Existing clients that don't read `errorCode` are unaffected. The `message` field is preserved and its values are unchanged.