### PR TITLE
fix: return real HTTP status for oversized client requests, cap dream batch

### DIFF
--- a/src/__tests__/error.middleware.test.ts
+++ b/src/__tests__/error.middleware.test.ts
@@ -1,0 +1,65 @@
+import type { NextFunction, Request, Response } from "express";
+import httpStatus from "http-status";
+import Joi from "joi";
+import { errorMiddleware } from "middlewares/error.middleware";
+import {
+  CLIENT_DREAMS_MAX_UUIDS,
+  clientDreamsRequestSchema,
+} from "schemas/client.schema";
+
+describe("errorMiddleware", () => {
+  const createRes = () => {
+    const json = jest.fn();
+    const status = jest.fn(() => ({ json }));
+    const res = {
+      status: status as unknown as Response["status"],
+    } as Response;
+    return { res, status, json };
+  };
+
+  const req = {} as Request;
+  const next: NextFunction = jest.fn();
+
+  it("honors an error's statusCode instead of masking it as 500 (e.g. PayloadTooLargeError -> 413)", () => {
+    const { res, status, json } = createRes();
+    const err = Object.assign(new Error("request entity too large"), {
+      statusCode: httpStatus.REQUEST_ENTITY_TOO_LARGE,
+    });
+
+    errorMiddleware(err, req, res, next);
+
+    expect(status).toHaveBeenCalledWith(httpStatus.REQUEST_ENTITY_TOO_LARGE);
+    // 4xx surfaces the real reason to the client
+    expect(json).toHaveBeenCalledWith({ message: "request entity too large" });
+  });
+
+  it("falls back to 500 for errors with no status", () => {
+    const { res, status, json } = createRes();
+
+    errorMiddleware(new Error("boom"), req, res, next);
+
+    expect(status).toHaveBeenCalledWith(httpStatus.INTERNAL_SERVER_ERROR);
+    // 5xx does not leak the internal error message
+    expect(json).toHaveBeenCalledWith({
+      message: expect.not.stringContaining("boom"),
+    });
+  });
+});
+
+describe("clientDreamsRequestSchema", () => {
+  const validate = (uuids: string[]) =>
+    Joi.object(clientDreamsRequestSchema).validate({ body: { uuids } });
+
+  const uuid = "00000000-0000-4000-8000-000000000000";
+
+  it("accepts a batch at the cap", () => {
+    const { error } = validate(Array(CLIENT_DREAMS_MAX_UUIDS).fill(uuid));
+    expect(error).toBeUndefined();
+  });
+
+  it("rejects a batch over the cap so oversized requests are refused cleanly", () => {
+    const { error } = validate(Array(CLIENT_DREAMS_MAX_UUIDS + 1).fill(uuid));
+    expect(error).toBeDefined();
+    expect(error?.message).toMatch(/less than or equal to 1000/);
+  });
+});

--- a/src/middlewares/error.middleware.ts
+++ b/src/middlewares/error.middleware.ts
@@ -4,13 +4,31 @@ import httpStatus from "http-status";
 import { APP_LOGGER } from "shared/logger";
 
 export const errorMiddleware = (
-  error: Error,
+  error: Error & { status?: number; statusCode?: number },
   _req: Request,
   res: Response,
   _next: NextFunction,
 ): void => {
-  APP_LOGGER.error(error);
-  res.status(httpStatus.INTERNAL_SERVER_ERROR).json({
-    message: GENERAL_MESSAGES.INTERNAL_SERVER_ERROR,
+  // Errors thrown by upstream middleware (e.g. body-parser's
+  // PayloadTooLargeError -> 413) carry their own HTTP status. Honor it instead
+  // of masking every error as a 500, so the client can distinguish a request it
+  // sent that was too large/malformed from a genuine server fault.
+  const status =
+    error.statusCode ?? error.status ?? httpStatus.INTERNAL_SERVER_ERROR;
+  const isServerError = status >= httpStatus.INTERNAL_SERVER_ERROR;
+
+  // Only genuine server faults are logged at error level; client-caused 4xx
+  // (oversized body, bad input) are warnings, not internal errors.
+  if (isServerError) {
+    APP_LOGGER.error(error);
+  } else {
+    APP_LOGGER.warn(error);
+  }
+
+  res.status(status).json({
+    // Don't leak internals on 5xx; surface the real reason on 4xx.
+    message: isServerError
+      ? GENERAL_MESSAGES.INTERNAL_SERVER_ERROR
+      : error.message ?? GENERAL_MESSAGES.INTERNAL_SERVER_ERROR,
   });
 };

--- a/src/schemas/client.schema.ts
+++ b/src/schemas/client.schema.ts
@@ -8,8 +8,17 @@ export const clientDreamsSchema: RequestValidationSchema = {
   }),
 };
 
+// Cap the batch size so a single request can't ask the server to load and
+// serialize an unbounded number of dreams. Large playlists (e.g. a
+// playlist-of-playlists) must page/chunk into requests of at most this many
+// uuids rather than sending everything at once. See client issue #522.
+export const CLIENT_DREAMS_MAX_UUIDS = 1000;
+
 export const clientDreamsRequestSchema: RequestValidationSchema = {
   body: Joi.object<GetDreamsRequestQuery>().keys({
-    uuids: Joi.array().items(Joi.string().uuid()).required(),
+    uuids: Joi.array()
+      .items(Joi.string().uuid())
+      .max(CLIENT_DREAMS_MAX_UUIDS)
+      .required(),
   }),
 };


### PR DESCRIPTION
## Context

Continuing [client #522](https://github.com/e-dream-ai/client/issues/522). Playing the "Everything" playlist (a playlist of ~58 playlists that the server flattens into **~6,300 dreams**) produced a server **500**. Reproduced live on `e-dream-prod`:

| Request | Result |
|---|---|
| `GET /api/v1/client/playlist/d323733e…` | **200**, 468 KB, 852 ms — fine |
| `POST /api/v1/client/dream` ×3 | **500** `PayloadTooLargeError: request entity too large`, ~40 ms |

The "500" is actually a misreported **413**:

1. The client (`FetchDreamsMetadata`) posts **all ~6,300 uuids in one ~245 KB body**, unchunked.
2. `bodyParser.json()` has no explicit limit → Express default **100 KB** → throws `PayloadTooLargeError` (status 413).
3. `errorMiddleware` mapped **every** error to 500, masking the real status.

It fails fast (~40 ms); nothing hangs or OOMs. (Note: there is no 59k-item playlist — that earlier figure was soft-deleted rows; the live max anyone plays is ~6,300.)

## Changes

- **`errorMiddleware`** now honors `error.statusCode`/`status` → `PayloadTooLargeError` returns **413**, not 500. 4xx are logged as warnings and surface the real reason; genuine 5xx still return the generic message (no internal leak).
- **`clientDreamsRequestSchema`** caps `uuids` at `CLIENT_DREAMS_MAX_UUIDS = 1000` → oversized batches refused cleanly with **400** instead of loading/serializing an unbounded number of dreams.
- New unit tests in `error.middleware.test.ts` for both (status passthrough + batch cap). Full suite passes; typecheck + lint clean.

## Scope / follow-ups

This is a **graceful-rejection stopgap** so we can test before the paged version. Playing "Everything" now returns a clean 413/400 instead of a confusing 500; the client (already hardened not to crash on errors) degrades gracefully.

- **Next:** client chunks `FetchDreamsMetadata` into ≤1,000-uuid batches + a paged endpoint (1,000 is the target batch size).
- Filed a separate backend issue for a `GET /client/playlist` size-guard (not needed by current data, but will be once aggregate playlists grow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)