### PR TITLE
fix: return real HTTP status for oversized client requests, cap dream…

### DIFF
--- a/src/__tests__/error.middleware.test.ts
+++ b/src/__tests__/error.middleware.test.ts
@@ -1,0 +1,65 @@
+import type { NextFunction, Request, Response } from "express";
+import httpStatus from "http-status";
+import Joi from "joi";
+import { errorMiddleware } from "middlewares/error.middleware";
+import {
+  CLIENT_DREAMS_MAX_UUIDS,
+  clientDreamsRequestSchema,
+} from "schemas/client.schema";
+
+describe("errorMiddleware", () => {
+  const createRes = () => {
+    const json = jest.fn();
+    const status = jest.fn(() => ({ json }));
+    const res = {
+      status: status as unknown as Response["status"],
+    } as Response;
+    return { res, status, json };
+  };
+
+  const req = {} as Request;
+  const next: NextFunction = jest.fn();
+
+  it("honors an error's statusCode instead of masking it as 500 (e.g. PayloadTooLargeError -> 413)", () => {
+    const { res, status, json } = createRes();
+    const err = Object.assign(new Error("request entity too large"), {
+      statusCode: httpStatus.REQUEST_ENTITY_TOO_LARGE,
+    });
+
+    errorMiddleware(err, req, res, next);
+
+    expect(status).toHaveBeenCalledWith(httpStatus.REQUEST_ENTITY_TOO_LARGE);
+    // 4xx surfaces the real reason to the client
+    expect(json).toHaveBeenCalledWith({ message: "request entity too large" });
+  });
+
+  it("falls back to 500 for errors with no status", () => {
+    const { res, status, json } = createRes();
+
+    errorMiddleware(new Error("boom"), req, res, next);
+
+    expect(status).toHaveBeenCalledWith(httpStatus.INTERNAL_SERVER_ERROR);
+    // 5xx does not leak the internal error message
+    expect(json).toHaveBeenCalledWith({
+      message: expect.not.stringContaining("boom"),
+    });
+  });
+});
+
+describe("clientDreamsRequestSchema", () => {
+  const validate = (uuids: string[]) =>
+    Joi.object(clientDreamsRequestSchema).validate({ body: { uuids } });
+
+  const uuid = "00000000-0000-4000-8000-000000000000";
+
+  it("accepts a batch at the cap", () => {
+    const { error } = validate(Array(CLIENT_DREAMS_MAX_UUIDS).fill(uuid));
+    expect(error).toBeUndefined();
+  });
+
+  it("rejects a batch over the cap so oversized requests are refused cleanly", () => {
+    const { error } = validate(Array(CLIENT_DREAMS_MAX_UUIDS + 1).fill(uuid));
+    expect(error).toBeDefined();
+    expect(error?.message).toMatch(/less than or equal to 1000/);
+  });
+});

--- a/src/middlewares/error.middleware.ts
+++ b/src/middlewares/error.middleware.ts
@@ -4,13 +4,31 @@ import httpStatus from "http-status";
 import { APP_LOGGER } from "shared/logger";
 
 export const errorMiddleware = (
-  error: Error,
+  error: Error & { status?: number; statusCode?: number },
   _req: Request,
   res: Response,
   _next: NextFunction,
 ): void => {
-  APP_LOGGER.error(error);
-  res.status(httpStatus.INTERNAL_SERVER_ERROR).json({
-    message: GENERAL_MESSAGES.INTERNAL_SERVER_ERROR,
+  // Errors thrown by upstream middleware (e.g. body-parser's
+  // PayloadTooLargeError -> 413) carry their own HTTP status. Honor it instead
+  // of masking every error as a 500, so the client can distinguish a request it
+  // sent that was too large/malformed from a genuine server fault.
+  const status =
+    error.statusCode ?? error.status ?? httpStatus.INTERNAL_SERVER_ERROR;
+  const isServerError = status >= httpStatus.INTERNAL_SERVER_ERROR;
+
+  // Only genuine server faults are logged at error level; client-caused 4xx
+  // (oversized body, bad input) are warnings, not internal errors.
+  if (isServerError) {
+    APP_LOGGER.error(error);
+  } else {
+    APP_LOGGER.warn(error);
+  }
+
+  res.status(status).json({
+    // Don't leak internals on 5xx; surface the real reason on 4xx.
+    message: isServerError
+      ? GENERAL_MESSAGES.INTERNAL_SERVER_ERROR
+      : error.message ?? GENERAL_MESSAGES.INTERNAL_SERVER_ERROR,
   });
 };

--- a/src/schemas/client.schema.ts
+++ b/src/schemas/client.schema.ts
@@ -8,8 +8,17 @@ export const clientDreamsSchema: RequestValidationSchema = {
   }),
 };
 
+// Cap the batch size so a single request can't ask the server to load and
+// serialize an unbounded number of dreams. Large playlists (e.g. a
+// playlist-of-playlists) must page/chunk into requests of at most this many
+// uuids rather than sending everything at once. See client issue #522.
+export const CLIENT_DREAMS_MAX_UUIDS = 1000;
+
 export const clientDreamsRequestSchema: RequestValidationSchema = {
   body: Joi.object<GetDreamsRequestQuery>().keys({
-    uuids: Joi.array().items(Joi.string().uuid()).required(),
+    uuids: Joi.array()
+      .items(Joi.string().uuid())
+      .max(CLIENT_DREAMS_MAX_UUIDS)
+      .required(),
   }),
 };


### PR DESCRIPTION
… batch (#441)

Playing a large playlist-of-playlists (e.g. "Everything", which flattens to ~6,300 dreams) made the client POST every uuid to /api/v1/client/dream in one ~245 KB body. That blew past bodyParser.json()'s default 100 KB limit, throwing PayloadTooLargeError (413) — but errorMiddleware masked every error as a 500, so it surfaced as a confusing "internal server error" (client issue #522).

- errorMiddleware now honors error.statusCode/status (so PayloadTooLargeError returns 413), logs 4xx as warnings, surfaces the real reason on 4xx, and keeps the generic message on genuine 5xx so internals aren't leaked.
- clientDreamsRequestSchema caps the uuids array at CLIENT_DREAMS_MAX_UUIDS (1000), so oversized batches are refused cleanly with a 400 instead of loading and serializing an unbounded number of dreams.

This is a graceful-rejection stopgap; the real fix is client chunking + a paged endpoint, for which 1000 is the target batch size.