### PR TITLE
Phase 1: API Key Config & i2i Variations — Backend

### DIFF
--- a/src/__tests__/url-safety.util.test.ts
+++ b/src/__tests__/url-safety.util.test.ts
@@ -1,0 +1,184 @@
+import dns from "dns";
+import type { LookupAddress } from "dns";
+import https from "https";
+import type { LookupFunction } from "net";
+
+describe("url-safety.util", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.restoreAllMocks();
+  });
+
+  describe("assertSafeExternalUrl — IP literal classification", () => {
+    // Adversarial table. IP-LITERAL urls are used so the FIX 2 short-circuit
+    // validates them directly (no DNS) → fully deterministic, hermetic.
+    const BLOCK: Array<[string, string]> = [
+      ["IPv4 loopback", "https://127.0.0.1/models"],
+      ["IPv4 private 10/8", "https://10.0.0.1/models"],
+      ["IPv4 private 172.16/12", "https://172.16.0.1/models"],
+      ["IPv4 private 192.168/16", "https://192.168.1.1/models"],
+      ["IPv4 link-local metadata", "https://169.254.169.254/models"],
+      ["IPv4 unspecified 0.0.0.0", "https://0.0.0.0/models"],
+      ["IPv6 loopback ::1", "https://[::1]/models"],
+      ["IPv6 link-local fe80::1", "https://[fe80::1]/models"],
+      ["IPv6 unique-local fc00::1", "https://[fc00::1]/models"],
+      ["IPv6 unique-local fd12:3456::1", "https://[fd12:3456::1]/models"],
+      ["IPv4-mapped dotted loopback", "https://[::ffff:127.0.0.1]/models"],
+      ["IPv4-mapped hex loopback", "https://[::ffff:7f00:1]/models"],
+      ["IPv4-mapped private 10", "https://[::ffff:10.0.0.1]/models"],
+      ["NAT64 well-known + loopback hex", "https://[64:ff9b::7f00:1]/models"],
+      ["NAT64 well-known + loopback dotted", "https://[64:ff9b::127.0.0.1]/models"],
+    ];
+
+    const ALLOW: Array<[string, string]> = [
+      ["IPv6 documentation 2001:db8::1", "https://[2001:db8::1]/models"],
+      ["IPv6 public Cloudflare DNS", "https://[2606:4700:4700::1111]/models"],
+      ["IPv4-mapped public 8.8.8.8", "https://[::ffff:8.8.8.8]/models"],
+      ["IPv4 outside RFC1918 (172.32)", "https://172.32.0.1/models"],
+    ];
+
+    it.each(BLOCK)("blocks %s", async (_label, url) => {
+      const { assertSafeExternalUrl } = await import("utils/url-safety.util");
+      await expect(assertSafeExternalUrl(url)).rejects.toThrow();
+    });
+
+    it.each(ALLOW)("allows %s", async (_label, url) => {
+      const { assertSafeExternalUrl } = await import("utils/url-safety.util");
+      const result = await assertSafeExternalUrl(url);
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it("blocks public IPv6 literal does NOT regress: [2606:4700:4700::1111] is allowed", async () => {
+      const { assertSafeExternalUrl } = await import("utils/url-safety.util");
+      const result = await assertSafeExternalUrl(
+        "https://[2606:4700:4700::1111]/models",
+      );
+      expect(result).toEqual([
+        { address: "2606:4700:4700::1111", family: 6 },
+      ]);
+    });
+
+    it("blocks IPv6 loopback literal [::1]", async () => {
+      const { assertSafeExternalUrl } = await import("utils/url-safety.util");
+      await expect(
+        assertSafeExternalUrl("https://[::1]/models"),
+      ).rejects.toThrow(/private\/internal address/);
+    });
+
+    it("returns the de-bracketed address (no brackets) for IPv6 literals", async () => {
+      const { assertSafeExternalUrl } = await import("utils/url-safety.util");
+      const result = await assertSafeExternalUrl("https://[2001:db8::1]/x");
+      expect(result[0].address).toBe("2001:db8::1");
+      expect(result[0].family).toBe(6);
+    });
+  });
+
+  describe("assertSafeExternalUrl — protocol and TLD checks", () => {
+    it("rejects non-https (http://) URLs", async () => {
+      const { assertSafeExternalUrl } = await import("utils/url-safety.util");
+      await expect(
+        assertSafeExternalUrl("http://8.8.8.8/models"),
+      ).rejects.toThrow(/https/);
+    });
+
+    it("rejects .internal TLD before DNS", async () => {
+      const lookupSpy = jest.spyOn(dns.promises, "lookup");
+      const { assertSafeExternalUrl } = await import("utils/url-safety.util");
+      await expect(
+        assertSafeExternalUrl("https://foo.internal/models"),
+      ).rejects.toThrow(/not allowed/);
+      expect(lookupSpy).not.toHaveBeenCalled();
+    });
+
+    it("rejects .local TLD before DNS", async () => {
+      const lookupSpy = jest.spyOn(dns.promises, "lookup");
+      const { assertSafeExternalUrl } = await import("utils/url-safety.util");
+      await expect(
+        assertSafeExternalUrl("https://foo.local/models"),
+      ).rejects.toThrow(/not allowed/);
+      expect(lookupSpy).not.toHaveBeenCalled();
+    });
+
+    it("rejects an unparseable URL", async () => {
+      const { assertSafeExternalUrl } = await import("utils/url-safety.util");
+      await expect(assertSafeExternalUrl("not a url")).rejects.toThrow(
+        /Invalid endpoint URL/,
+      );
+    });
+  });
+
+  describe("assertSafeExternalUrl — hostname DNS resolution (mocked)", () => {
+    it("allows a public hostname that resolves to a public address", async () => {
+      jest
+        .spyOn(dns.promises, "lookup")
+        // @ts-expect-error overload: { all: true } returns LookupAddress[]
+        .mockResolvedValue([
+          { address: "93.184.216.34", family: 4 },
+        ] as LookupAddress[]);
+      const { assertSafeExternalUrl } = await import("utils/url-safety.util");
+      const result = await assertSafeExternalUrl("https://example.com/models");
+      expect(result).toEqual([{ address: "93.184.216.34", family: 4 }]);
+    });
+
+    it("blocks when ANY resolved address is private (all-addresses loop)", async () => {
+      jest
+        .spyOn(dns.promises, "lookup")
+        // @ts-expect-error overload: { all: true } returns LookupAddress[]
+        .mockResolvedValue([
+          { address: "93.184.216.34", family: 4 }, // public
+          { address: "10.0.0.1", family: 4 }, // private — must trigger block
+        ] as LookupAddress[]);
+      const { assertSafeExternalUrl } = await import("utils/url-safety.util");
+      await expect(
+        assertSafeExternalUrl("https://rebind.example.com/models"),
+      ).rejects.toThrow(/disallowed address/);
+    });
+
+    it("rejects when DNS resolution fails", async () => {
+      jest
+        .spyOn(dns.promises, "lookup")
+        .mockRejectedValue(new Error("ENOTFOUND"));
+      const { assertSafeExternalUrl } = await import("utils/url-safety.util");
+      await expect(
+        assertSafeExternalUrl("https://no-such-host.example/models"),
+      ).rejects.toThrow(/Could not resolve/);
+    });
+  });
+
+  describe("createPinnedAgent — Node lookup contract (the FIX 1 regression)", () => {
+    // Reach into the Agent's lookup option that Node merges into TLS connect.
+    function getAgentLookup(agent: https.Agent): LookupFunction {
+      const lookup = (agent.options as { lookup?: LookupFunction }).lookup;
+      if (!lookup) throw new Error("Agent has no lookup option");
+      return lookup;
+    }
+
+    it("returns an ARRAY when called with { all: true } (the exact regression)", async () => {
+      const { __test } = await import("services/endpoint-tester.service");
+      const agent = __test.createPinnedAgent({
+        address: "93.184.216.34",
+        family: 4,
+      });
+      const lookup = getAgentLookup(agent);
+      const cb = jest.fn();
+      lookup("example.com", { all: true } as dns.LookupAllOptions, cb);
+      expect(cb).toHaveBeenCalledTimes(1);
+      expect(cb).toHaveBeenCalledWith(null, [
+        { address: "93.184.216.34", family: 4 },
+      ]);
+    });
+
+    it("uses the positional form when called with { all: false }", async () => {
+      const { __test } = await import("services/endpoint-tester.service");
+      const agent = __test.createPinnedAgent({
+        address: "2606:4700:4700::1111",
+        family: 6,
+      });
+      const lookup = getAgentLookup(agent);
+      const cb = jest.fn();
+      lookup("cloudflare-dns.com", { all: false } as dns.LookupOptions, cb);
+      expect(cb).toHaveBeenCalledTimes(1);
+      expect(cb).toHaveBeenCalledWith(null, "2606:4700:4700::1111", 6);
+    });
+  });
+});

--- a/src/controllers/user-api-endpoint.controller.ts
+++ b/src/controllers/user-api-endpoint.controller.ts
@@ -1,0 +1,110 @@
+import httpStatus from "http-status";
+import { RequestType, ResponseType } from "types/express.types";
+import { jsonResponse, handleInternalServerError } from "utils/responses.util";
+import * as userApiEndpointService from "services/user-api-endpoint.service";
+
+export const handleListEndpoints = async (
+  req: RequestType,
+  res: ResponseType,
+) => {
+  try {
+    const userId = req.user!.id;
+    const endpoints = await userApiEndpointService.list(userId);
+    res
+      .status(httpStatus.OK)
+      .json(jsonResponse({ success: true, data: { endpoints } }));
+  } catch (err) {
+    handleInternalServerError(err as Error, req, res);
+  }
+};
+
+export const handleCreateEndpoint = async (
+  req: RequestType,
+  res: ResponseType,
+) => {
+  try {
+    const userId = req.user!.id;
+    const result = await userApiEndpointService.create(userId, req.body);
+
+    if (!result.success) {
+      return res
+        .status(httpStatus.BAD_REQUEST)
+        .json(jsonResponse({ success: false, message: result.error }));
+    }
+
+    res
+      .status(httpStatus.CREATED)
+      .json(
+        jsonResponse({ success: true, data: { endpoint: result.endpoint } }),
+      );
+  } catch (err) {
+    handleInternalServerError(err as Error, req, res);
+  }
+};
+
+export const handleUpdateEndpoint = async (
+  req: RequestType,
+  res: ResponseType,
+) => {
+  try {
+    const userId = req.user!.id;
+    const { uuid } = req.params as { uuid: string };
+    const result = await userApiEndpointService.update(uuid, userId, req.body);
+
+    if (!result.success) {
+      return res
+        .status(httpStatus.BAD_REQUEST)
+        .json(jsonResponse({ success: false, message: result.error }));
+    }
+
+    res
+      .status(httpStatus.OK)
+      .json(
+        jsonResponse({ success: true, data: { endpoint: result.endpoint } }),
+      );
+  } catch (err) {
+    handleInternalServerError(err as Error, req, res);
+  }
+};
+
+export const handleDeleteEndpoint = async (
+  req: RequestType,
+  res: ResponseType,
+) => {
+  try {
+    const userId = req.user!.id;
+    const { uuid } = req.params as { uuid: string };
+    const result = await userApiEndpointService.remove(uuid, userId);
+
+    if (!result.success) {
+      return res
+        .status(httpStatus.NOT_FOUND)
+        .json(jsonResponse({ success: false, message: result.error }));
+    }
+
+    res.status(httpStatus.OK).json(jsonResponse({ success: true }));
+  } catch (err) {
+    handleInternalServerError(err as Error, req, res);
+  }
+};
+
+export const handleTestEndpoint = async (
+  req: RequestType,
+  res: ResponseType,
+) => {
+  try {
+    const userId = req.user!.id;
+    const { uuid } = req.params as { uuid: string };
+    const result = await userApiEndpointService.test(uuid, userId);
+
+    if (!result.success) {
+      return res
+        .status(httpStatus.BAD_REQUEST)
+        .json(jsonResponse({ success: false, message: result.error }));
+    }
+
+    res.status(httpStatus.OK).json(jsonResponse({ success: true }));
+  } catch (err) {
+    handleInternalServerError(err as Error, req, res);
+  }
+};

--- a/src/controllers/user-api-endpoint.controller.ts
+++ b/src/controllers/user-api-endpoint.controller.ts
@@ -1,4 +1,8 @@
 import httpStatus from "http-status";
+import {
+  CreateUserApiEndpointRequest,
+  UpdateUserApiEndpointRequest,
+} from "types/user-api-endpoint.types";
 import { RequestType, ResponseType } from "types/express.types";
 import { jsonResponse, handleInternalServerError } from "utils/responses.util";
 import * as userApiEndpointService from "services/user-api-endpoint.service";
@@ -8,7 +12,7 @@ export const handleListEndpoints = async (
   res: ResponseType,
 ) => {
   try {
-    const userId = req.user!.id;
+    const userId = res.locals.user!.id;
     const endpoints = await userApiEndpointService.list(userId);
     res
       .status(httpStatus.OK)
@@ -19,12 +23,15 @@ export const handleListEndpoints = async (
 };
 
 export const handleCreateEndpoint = async (
-  req: RequestType,
+  req: RequestType<CreateUserApiEndpointRequest>,
   res: ResponseType,
 ) => {
   try {
-    const userId = req.user!.id;
-    const result = await userApiEndpointService.create(userId, req.body);
+    const userId = res.locals.user!.id;
+    const result = await userApiEndpointService.create(
+      userId,
+      req.body as CreateUserApiEndpointRequest,
+    );
 
     if (!result.success) {
       return res
@@ -43,13 +50,17 @@ export const handleCreateEndpoint = async (
 };
 
 export const handleUpdateEndpoint = async (
-  req: RequestType,
+  req: RequestType<UpdateUserApiEndpointRequest>,
   res: ResponseType,
 ) => {
   try {
-    const userId = req.user!.id;
+    const userId = res.locals.user!.id;
     const { uuid } = req.params as { uuid: string };
-    const result = await userApiEndpointService.update(uuid, userId, req.body);
+    const result = await userApiEndpointService.update(
+      uuid,
+      userId,
+      req.body as UpdateUserApiEndpointRequest,
+    );
 
     if (!result.success) {
       return res
@@ -72,7 +83,7 @@ export const handleDeleteEndpoint = async (
   res: ResponseType,
 ) => {
   try {
-    const userId = req.user!.id;
+    const userId = res.locals.user!.id;
     const { uuid } = req.params as { uuid: string };
     const result = await userApiEndpointService.remove(uuid, userId);
 
@@ -93,7 +104,7 @@ export const handleTestEndpoint = async (
   res: ResponseType,
 ) => {
   try {
-    const userId = req.user!.id;
+    const userId = res.locals.user!.id;
     const { uuid } = req.params as { uuid: string };
     const result = await userApiEndpointService.test(uuid, userId);
 

--- a/src/entities/UserApiEndpoint.entity.ts
+++ b/src/entities/UserApiEndpoint.entity.ts
@@ -6,6 +6,7 @@ import {
   JoinColumn,
   CreateDateColumn,
   UpdateDateColumn,
+  DeleteDateColumn,
   Index,
   Generated,
 } from "typeorm";
@@ -20,7 +21,7 @@ export class UserApiEndpoint {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column({ type: "varchar", unique: true })
+  @Column({ type: "string", unique: true })
   @Generated("uuid")
   @Index()
   uuid: string;
@@ -61,8 +62,11 @@ export class UserApiEndpoint {
   capabilities: EndpointCapabilities;
 
   @CreateDateColumn()
-  createdAt: Date;
+  created_at: Date;
 
   @UpdateDateColumn()
-  updatedAt: Date;
+  updated_at: Date;
+
+  @DeleteDateColumn()
+  deleted_at: Date;
 }

--- a/src/entities/UserApiEndpoint.entity.ts
+++ b/src/entities/UserApiEndpoint.entity.ts
@@ -1,0 +1,68 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+  Generated,
+} from "typeorm";
+import { User } from "./User.entity";
+import type {
+  EndpointProviderType,
+  EndpointCapabilities,
+} from "../types/user-api-endpoint.types";
+
+@Entity("user_api_endpoint")
+export class UserApiEndpoint {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: "varchar", unique: true })
+  @Generated("uuid")
+  @Index()
+  uuid: string;
+
+  @Column()
+  @Index()
+  userId: number;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: "userId" })
+  user: User;
+
+  @Column()
+  name: string;
+
+  @Column()
+  providerType: EndpointProviderType;
+
+  @Column()
+  presetId: string;
+
+  @Column()
+  endpointUrl: string;
+
+  @Column()
+  apiKeyEncrypted: string;
+
+  @Column()
+  apiKeyIv: string;
+
+  @Column({ length: 4 })
+  apiKeyLastFour: string;
+
+  @Column()
+  modelId: string;
+
+  @Column({ type: "jsonb" })
+  capabilities: EndpointCapabilities;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/migrations/1775000000000-AddUserApiEndpoints.ts
+++ b/src/migrations/1775000000000-AddUserApiEndpoints.ts
@@ -1,0 +1,49 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddUserApiEndpoints1775000000000 implements MigrationInterface {
+  name = "AddUserApiEndpoints1775000000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "user_api_endpoint" (` +
+        `"id" SERIAL NOT NULL, ` +
+        `"uuid" character varying NOT NULL DEFAULT uuid_generate_v4(), ` +
+        `"userId" integer NOT NULL, ` +
+        `"name" character varying NOT NULL, ` +
+        `"providerType" character varying NOT NULL, ` +
+        `"presetId" character varying NOT NULL, ` +
+        `"endpointUrl" character varying NOT NULL, ` +
+        `"apiKeyEncrypted" character varying NOT NULL, ` +
+        `"apiKeyIv" character varying NOT NULL, ` +
+        `"apiKeyLastFour" character varying(4) NOT NULL, ` +
+        `"modelId" character varying NOT NULL, ` +
+        `"capabilities" jsonb NOT NULL, ` +
+        `"createdAt" TIMESTAMP NOT NULL DEFAULT now(), ` +
+        `"updatedAt" TIMESTAMP NOT NULL DEFAULT now(), ` +
+        `CONSTRAINT "UQ_user_api_endpoint_uuid" UNIQUE ("uuid"), ` +
+        `CONSTRAINT "PK_user_api_endpoint" PRIMARY KEY ("id")` +
+        `)`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_user_api_endpoint_uuid" ON "user_api_endpoint" ("uuid")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_user_api_endpoint_userId" ON "user_api_endpoint" ("userId")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_api_endpoint" ADD CONSTRAINT "FK_user_api_endpoint_user" ` +
+        `FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user_api_endpoint" DROP CONSTRAINT "FK_user_api_endpoint_user"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_user_api_endpoint_userId"`,
+    );
+    await queryRunner.query(`DROP INDEX "public"."IDX_user_api_endpoint_uuid"`);
+    await queryRunner.query(`DROP TABLE "user_api_endpoint"`);
+  }
+}

--- a/src/migrations/1775000000000-AddUserApiEndpoints.ts
+++ b/src/migrations/1775000000000-AddUserApiEndpoints.ts
@@ -18,8 +18,9 @@ export class AddUserApiEndpoints1775000000000 implements MigrationInterface {
         `"apiKeyLastFour" character varying(4) NOT NULL, ` +
         `"modelId" character varying NOT NULL, ` +
         `"capabilities" jsonb NOT NULL, ` +
-        `"createdAt" TIMESTAMP NOT NULL DEFAULT now(), ` +
-        `"updatedAt" TIMESTAMP NOT NULL DEFAULT now(), ` +
+        `"created_at" TIMESTAMP NOT NULL DEFAULT now(), ` +
+        `"updated_at" TIMESTAMP NOT NULL DEFAULT now(), ` +
+        `"deleted_at" TIMESTAMP, ` +
         `CONSTRAINT "UQ_user_api_endpoint_uuid" UNIQUE ("uuid"), ` +
         `CONSTRAINT "PK_user_api_endpoint" PRIMARY KEY ("id")` +
         `)`,
@@ -32,7 +33,7 @@ export class AddUserApiEndpoints1775000000000 implements MigrationInterface {
     );
     await queryRunner.query(
       `ALTER TABLE "user_api_endpoint" ADD CONSTRAINT "FK_user_api_endpoint_user" ` +
-        `FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+        `FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
     );
   }
 

--- a/src/routes/v1/router.ts
+++ b/src/routes/v1/router.ts
@@ -18,6 +18,7 @@ import marketingRouter from "routes/v1/marketing.routes";
 import heapSnapshotRouter from "routes/v1/heap-snapshot.routes";
 import simulateAuthFailureRouter from "routes/v1/simulate-auth-failure.routes";
 import simulateHelloRouter from "routes/v1/simulate-hello.routes";
+import userApiEndpointRouter from "routes/v1/user-api-endpoint.routes";
 import authRouterV2 from "routes/v2/auth.routes";
 import webhooksRouterV2 from "routes/v2/webhooks.routes";
 import { jsonResponse } from "utils/responses.util";
@@ -534,6 +535,9 @@ export const registerRoutes = (app: express.Application) => {
 
   // register simulate hello router (internal, protected by x-internal-key header)
   app.use("/api/v1/internal/simulate-hello", simulateHelloRouter);
+
+  // register user api endpoint router
+  app.use("/api/v1/user/api-endpoints", userApiEndpointRouter);
 
   // register v2 auth
   app.use("/api/v2/auth", authRouterV2);

--- a/src/routes/v1/router.ts
+++ b/src/routes/v1/router.ts
@@ -500,6 +500,9 @@ export const registerRoutes = (app: express.Application) => {
   // register user router
   app.use("/api/v1/auth", authRouter);
 
+  // register user api endpoint router
+  app.use("/api/v1/user/api-endpoints", userApiEndpointRouter);
+
   // register auth router
   app.use("/api/v1/user", userRouter);
 
@@ -535,9 +538,6 @@ export const registerRoutes = (app: express.Application) => {
 
   // register simulate hello router (internal, protected by x-internal-key header)
   app.use("/api/v1/internal/simulate-hello", simulateHelloRouter);
-
-  // register user api endpoint router
-  app.use("/api/v1/user/api-endpoints", userApiEndpointRouter);
 
   // register v2 auth
   app.use("/api/v2/auth", authRouterV2);

--- a/src/routes/v1/user-api-endpoint.routes.ts
+++ b/src/routes/v1/user-api-endpoint.routes.ts
@@ -1,0 +1,33 @@
+import { Router } from "express";
+import { requireAuth } from "middlewares/require-auth.middleware";
+import * as userApiEndpointController from "controllers/user-api-endpoint.controller";
+
+const userApiEndpointRouter = Router();
+
+userApiEndpointRouter.get(
+  "/",
+  requireAuth,
+  userApiEndpointController.handleListEndpoints,
+);
+userApiEndpointRouter.post(
+  "/",
+  requireAuth,
+  userApiEndpointController.handleCreateEndpoint,
+);
+userApiEndpointRouter.put(
+  "/:uuid",
+  requireAuth,
+  userApiEndpointController.handleUpdateEndpoint,
+);
+userApiEndpointRouter.delete(
+  "/:uuid",
+  requireAuth,
+  userApiEndpointController.handleDeleteEndpoint,
+);
+userApiEndpointRouter.post(
+  "/:uuid/test",
+  requireAuth,
+  userApiEndpointController.handleTestEndpoint,
+);
+
+export default userApiEndpointRouter;

--- a/src/routes/v1/user-api-endpoint.routes.ts
+++ b/src/routes/v1/user-api-endpoint.routes.ts
@@ -1,6 +1,12 @@
 import { Router } from "express";
 import { requireAuth } from "middlewares/require-auth.middleware";
+import validatorMiddleware from "middlewares/validator.middleware";
 import * as userApiEndpointController from "controllers/user-api-endpoint.controller";
+import {
+  createUserApiEndpointSchema,
+  endpointParamsSchema,
+  updateUserApiEndpointSchema,
+} from "schemas/user-api-endpoint.schema";
 
 const userApiEndpointRouter = Router();
 
@@ -12,21 +18,25 @@ userApiEndpointRouter.get(
 userApiEndpointRouter.post(
   "/",
   requireAuth,
+  validatorMiddleware(createUserApiEndpointSchema),
   userApiEndpointController.handleCreateEndpoint,
 );
 userApiEndpointRouter.put(
   "/:uuid",
   requireAuth,
+  validatorMiddleware(updateUserApiEndpointSchema),
   userApiEndpointController.handleUpdateEndpoint,
 );
 userApiEndpointRouter.delete(
   "/:uuid",
   requireAuth,
+  validatorMiddleware(endpointParamsSchema),
   userApiEndpointController.handleDeleteEndpoint,
 );
 userApiEndpointRouter.post(
   "/:uuid/test",
   requireAuth,
+  validatorMiddleware(endpointParamsSchema),
   userApiEndpointController.handleTestEndpoint,
 );
 

--- a/src/schemas/user-api-endpoint.schema.ts
+++ b/src/schemas/user-api-endpoint.schema.ts
@@ -1,0 +1,49 @@
+import Joi from "joi";
+import {
+  CreateUserApiEndpointRequest,
+  UpdateUserApiEndpointRequest,
+} from "types/user-api-endpoint.types";
+import { RequestValidationSchema } from "types/validator.types";
+
+const providerTypes = ["openai", "fal"] as const;
+
+const capabilitiesSchema = Joi.object({
+  textToImage: Joi.boolean().required(),
+  imageToImage: Joi.boolean().required(),
+  sizes: Joi.array().items(Joi.string()).required(),
+});
+
+const httpsUrl = Joi.string().uri({ scheme: ["https"] });
+
+export const endpointParamsSchema: RequestValidationSchema = {
+  params: Joi.object().keys({
+    uuid: Joi.string().uuid().required(),
+  }),
+};
+
+export const createUserApiEndpointSchema: RequestValidationSchema = {
+  body: Joi.object<CreateUserApiEndpointRequest>().keys({
+    name: Joi.string().required().max(255),
+    providerType: Joi.string()
+      .valid(...providerTypes)
+      .required(),
+    presetId: Joi.string().required(),
+    endpointUrl: httpsUrl.required(),
+    apiKey: Joi.string().required(),
+    modelId: Joi.string().required(),
+    capabilities: capabilitiesSchema.required(),
+  }),
+};
+
+export const updateUserApiEndpointSchema: RequestValidationSchema = {
+  body: Joi.object<UpdateUserApiEndpointRequest>().keys({
+    name: Joi.string().max(255),
+    endpointUrl: httpsUrl,
+    apiKey: Joi.string(),
+    modelId: Joi.string(),
+    capabilities: capabilitiesSchema,
+  }),
+  params: Joi.object().keys({
+    uuid: Joi.string().uuid().required(),
+  }),
+};

--- a/src/services/endpoint-tester.service.ts
+++ b/src/services/endpoint-tester.service.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import type { EndpointProviderType } from "../types/user-api-endpoint.types";
 import { APP_LOGGER } from "shared/logger";
+import { assertSafeExternalUrl } from "utils/url-safety.util";
 
 interface TestResult {
   success: boolean;
@@ -31,6 +32,7 @@ async function testOpenAiEndpoint(
   apiKey: string,
 ): Promise<TestResult> {
   try {
+    await assertSafeExternalUrl(`${endpointUrl}/models`);
     const response = await axios.get(`${endpointUrl}/models`, {
       headers: { Authorization: `Bearer ${apiKey}` },
       timeout: 15000,
@@ -60,6 +62,7 @@ async function testFalEndpoint(
   apiKey: string,
 ): Promise<TestResult> {
   try {
+    await assertSafeExternalUrl(endpointUrl);
     const response = await axios.post(
       endpointUrl,
       { prompt: "test", image_size: "square", num_images: 1 },

--- a/src/services/endpoint-tester.service.ts
+++ b/src/services/endpoint-tester.service.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import dns from "dns";
 import https from "https";
 import type { LookupFunction } from "net";
 import type { EndpointProviderType } from "../types/user-api-endpoint.types";
@@ -23,12 +24,37 @@ interface TestResult {
  * escape the pin either.
  */
 function createPinnedAgent(pinned: SafeAddress): https.Agent {
-  const lookup: LookupFunction = (_hostname, _options, callback) => {
-    // Always resolve to the already-validated address.
-    callback(null, pinned.address, pinned.family);
+  // Always resolve to the already-validated address. Node invokes the Agent's
+  // `lookup` with `options.all === true` during HTTPS connect and then expects
+  // the callback to receive an ARRAY of { address, family }. The positional
+  // form (callback(null, address, family)) is only correct when `all` is false;
+  // using it under `all: true` makes Node read `address = undefined` and throw
+  // ERR_INVALID_IP_ADDRESS, breaking every pinned request. Handle both modes.
+  //
+  // Note: we do NOT set `servername`, so SNI and the Host header keep the
+  // original hostname — only the socket's destination IP is pinned, so TLS
+  // certificate validation still works.
+  const lookup: LookupFunction = (_hostname, options, callback) => {
+    if ((options as dns.LookupOptions)?.all) {
+      (
+        callback as (
+          err: NodeJS.ErrnoException | null,
+          addresses: Array<{ address: string; family: number }>,
+        ) => void
+      )(null, [{ address: pinned.address, family: pinned.family }]);
+    } else {
+      callback(null, pinned.address, pinned.family);
+    }
   };
   return new https.Agent({ lookup });
 }
+
+/**
+ * Test-only surface. Exposes internals (the pinned-lookup agent factory) so the
+ * Node DNS `lookup` callback contract can be exercised directly in unit tests
+ * without performing live network requests. Not part of the public API.
+ */
+export const __test = { createPinnedAgent };
 
 export async function testEndpointConnection(
   providerType: EndpointProviderType,

--- a/src/services/endpoint-tester.service.ts
+++ b/src/services/endpoint-tester.service.ts
@@ -1,11 +1,33 @@
 import axios from "axios";
+import https from "https";
+import type { LookupFunction } from "net";
 import type { EndpointProviderType } from "../types/user-api-endpoint.types";
 import { APP_LOGGER } from "shared/logger";
-import { assertSafeExternalUrl } from "utils/url-safety.util";
+import { assertSafeExternalUrl, SafeAddress } from "utils/url-safety.util";
 
 interface TestResult {
   success: boolean;
   error?: string;
+}
+
+/**
+ * Builds an https.Agent that pins the TLS connection to a pre-validated IP
+ * address. Node merges the Agent's options (including `lookup`) into the TLS
+ * connect options, so the socket connects to `pinned.address` while SNI and
+ * the Host header still carry the original hostname.
+ *
+ * This closes the DNS-rebinding TOCTOU: assertSafeExternalUrl resolved and
+ * validated the hostname, and we now force axios to connect to that exact
+ * address instead of re-resolving (which could return a private IP at request
+ * time). Combined with `maxRedirects: 0` on the request, a redirect cannot
+ * escape the pin either.
+ */
+function createPinnedAgent(pinned: SafeAddress): https.Agent {
+  const lookup: LookupFunction = (_hostname, _options, callback) => {
+    // Always resolve to the already-validated address.
+    callback(null, pinned.address, pinned.family);
+  };
+  return new https.Agent({ lookup });
 }
 
 export async function testEndpointConnection(
@@ -32,10 +54,12 @@ async function testOpenAiEndpoint(
   apiKey: string,
 ): Promise<TestResult> {
   try {
-    await assertSafeExternalUrl(`${endpointUrl}/models`);
+    const [pinned] = await assertSafeExternalUrl(`${endpointUrl}/models`);
     const response = await axios.get(`${endpointUrl}/models`, {
       headers: { Authorization: `Bearer ${apiKey}` },
       timeout: 15000,
+      httpsAgent: createPinnedAgent(pinned),
+      maxRedirects: 0,
     });
     if (response.status === 200) return { success: true };
     return { success: false, error: `Unexpected status: ${response.status}` };
@@ -62,13 +86,15 @@ async function testFalEndpoint(
   apiKey: string,
 ): Promise<TestResult> {
   try {
-    await assertSafeExternalUrl(endpointUrl);
+    const [pinned] = await assertSafeExternalUrl(endpointUrl);
     const response = await axios.post(
       endpointUrl,
       { prompt: "test", image_size: "square", num_images: 1 },
       {
         headers: { Authorization: `Key ${apiKey}` },
         timeout: 15000,
+        httpsAgent: createPinnedAgent(pinned),
+        maxRedirects: 0,
       },
     );
     if (response.status >= 200 && response.status < 300)

--- a/src/services/endpoint-tester.service.ts
+++ b/src/services/endpoint-tester.service.ts
@@ -1,0 +1,91 @@
+import axios from "axios";
+import type { EndpointProviderType } from "../types/user-api-endpoint.types";
+import { APP_LOGGER } from "shared/logger";
+
+interface TestResult {
+  success: boolean;
+  error?: string;
+}
+
+export async function testEndpointConnection(
+  providerType: EndpointProviderType,
+  endpointUrl: string,
+  apiKey: string,
+): Promise<TestResult> {
+  try {
+    if (providerType === "openai") {
+      return await testOpenAiEndpoint(endpointUrl, apiKey);
+    } else if (providerType === "fal") {
+      return await testFalEndpoint(endpointUrl, apiKey);
+    }
+    return { success: false, error: `Unknown provider type: ${providerType}` };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    APP_LOGGER.error(`Endpoint test failed: ${message}`);
+    return { success: false, error: message };
+  }
+}
+
+async function testOpenAiEndpoint(
+  endpointUrl: string,
+  apiKey: string,
+): Promise<TestResult> {
+  try {
+    const response = await axios.get(`${endpointUrl}/models`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      timeout: 15000,
+    });
+    if (response.status === 200) return { success: true };
+    return { success: false, error: `Unexpected status: ${response.status}` };
+  } catch (err: unknown) {
+    if (axios.isAxiosError(err)) {
+      if (err.response?.status === 401)
+        return { success: false, error: "Invalid API key" };
+      if (err.response?.status === 403)
+        return {
+          success: false,
+          error: "API key lacks required permissions",
+        };
+      return {
+        success: false,
+        error: `Connection failed: ${err.response?.status ?? err.message}`,
+      };
+    }
+    throw err;
+  }
+}
+
+async function testFalEndpoint(
+  endpointUrl: string,
+  apiKey: string,
+): Promise<TestResult> {
+  try {
+    const response = await axios.post(
+      endpointUrl,
+      { prompt: "test", image_size: "square", num_images: 1 },
+      {
+        headers: { Authorization: `Key ${apiKey}` },
+        timeout: 15000,
+      },
+    );
+    if (response.status >= 200 && response.status < 300)
+      return { success: true };
+    return { success: false, error: `Unexpected status: ${response.status}` };
+  } catch (err: unknown) {
+    if (axios.isAxiosError(err)) {
+      if (err.response?.status === 401)
+        return { success: false, error: "Invalid API key" };
+      if (err.response?.status === 403)
+        return {
+          success: false,
+          error: "API key lacks required permissions",
+        };
+      if (err.response?.status === 422) return { success: true }; // bad params but auth passed
+      return {
+        success: false,
+        error: `Connection failed: ${err.response?.status ?? err.message}`,
+      };
+    }
+    throw err;
+  }
+}

--- a/src/services/user-api-endpoint.service.ts
+++ b/src/services/user-api-endpoint.service.ts
@@ -4,10 +4,12 @@ import { encrypt, decrypt } from "utils/crypto.util";
 import { APP_LOGGER } from "shared/logger";
 import {
   CreateUserApiEndpointRequest,
+  EndpointProviderType,
   UpdateUserApiEndpointRequest,
   UserApiEndpointResponse,
 } from "types/user-api-endpoint.types";
 import { testEndpointConnection } from "./endpoint-tester.service";
+import { assertSafeExternalUrl } from "utils/url-safety.util";
 
 const endpointRepository = appDataSource.getRepository(UserApiEndpoint);
 
@@ -46,6 +48,13 @@ export async function create(
   endpoint?: UserApiEndpointResponse;
   error?: string;
 }> {
+  try {
+    await assertSafeExternalUrl(data.endpointUrl);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "Invalid endpoint URL";
+    return { success: false, error: message };
+  }
+
   const testResult = await testEndpointConnection(
     data.providerType,
     data.endpointUrl,
@@ -91,6 +100,14 @@ export async function update(
 
   if (!endpoint) {
     return { success: false, error: "Endpoint not found" };
+  }
+
+  const effectiveUrl = data.endpointUrl ?? endpoint.endpointUrl;
+  try {
+    await assertSafeExternalUrl(effectiveUrl);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "Invalid endpoint URL";
+    return { success: false, error: message };
   }
 
   if (data.apiKey) {
@@ -171,6 +188,28 @@ export async function decryptKey(
   uuid: string,
   userId: number,
 ): Promise<string | null> {
+  const resolved = await resolveEndpointForJob(uuid, userId);
+  return resolved ? resolved.decryptedKey : null;
+}
+
+export interface ResolvedEndpointForJob {
+  decryptedKey: string;
+  endpointUrl: string;
+  providerType: EndpointProviderType;
+  modelId: string;
+}
+
+/**
+ * Resolves a user endpoint into everything the worker needs to run a job:
+ * the decrypted API key plus the endpoint URL, provider type, and model id.
+ *
+ * @returns the resolved endpoint, or null if the endpoint is not found or the
+ *          key cannot be decrypted (decrypt failures are logged distinctly).
+ */
+export async function resolveEndpointForJob(
+  uuid: string,
+  userId: number,
+): Promise<ResolvedEndpointForJob | null> {
   const endpoint = await endpointRepository.findOne({
     where: { uuid, userId },
   });
@@ -179,14 +218,24 @@ export async function decryptKey(
     return null;
   }
 
+  let decryptedKey: string;
   try {
-    return decrypt({
+    decryptedKey = decrypt({
       iv: endpoint.apiKeyIv,
       content: endpoint.apiKeyEncrypted,
     });
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : "Unknown error";
-    APP_LOGGER.error(`Failed to decrypt key for endpoint ${uuid}: ${message}`);
+    APP_LOGGER.error(
+      `Failed to decrypt key for endpoint ${uuid} (user ${userId}): ${message}`,
+    );
     return null;
   }
+
+  return {
+    decryptedKey,
+    endpointUrl: endpoint.endpointUrl,
+    providerType: endpoint.providerType,
+    modelId: endpoint.modelId,
+  };
 }

--- a/src/services/user-api-endpoint.service.ts
+++ b/src/services/user-api-endpoint.service.ts
@@ -184,14 +184,6 @@ export async function test(
   }
 }
 
-export async function decryptKey(
-  uuid: string,
-  userId: number,
-): Promise<string | null> {
-  const resolved = await resolveEndpointForJob(uuid, userId);
-  return resolved ? resolved.decryptedKey : null;
-}
-
 export interface ResolvedEndpointForJob {
   decryptedKey: string;
   endpointUrl: string;

--- a/src/services/user-api-endpoint.service.ts
+++ b/src/services/user-api-endpoint.service.ts
@@ -1,0 +1,192 @@
+import appDataSource from "database/app-data-source";
+import { UserApiEndpoint } from "entities/UserApiEndpoint.entity";
+import { encrypt, decrypt } from "utils/crypto.util";
+import { APP_LOGGER } from "shared/logger";
+import {
+  CreateUserApiEndpointRequest,
+  UpdateUserApiEndpointRequest,
+  UserApiEndpointResponse,
+} from "types/user-api-endpoint.types";
+import { testEndpointConnection } from "./endpoint-tester.service";
+
+const endpointRepository = appDataSource.getRepository(UserApiEndpoint);
+
+function lastFour(apiKey: string): string {
+  return apiKey.slice(-4);
+}
+
+function toResponse(entity: UserApiEndpoint): UserApiEndpointResponse {
+  return {
+    uuid: entity.uuid,
+    name: entity.name,
+    providerType: entity.providerType,
+    presetId: entity.presetId,
+    endpointUrl: entity.endpointUrl,
+    apiKeyLastFour: entity.apiKeyLastFour,
+    modelId: entity.modelId,
+    capabilities: entity.capabilities,
+    createdAt: entity.created_at,
+    updatedAt: entity.updated_at,
+  };
+}
+
+export async function list(userId: number): Promise<UserApiEndpointResponse[]> {
+  const endpoints = await endpointRepository.find({
+    where: { userId },
+    order: { created_at: "DESC" },
+  });
+  return endpoints.map(toResponse);
+}
+
+export async function create(
+  userId: number,
+  data: CreateUserApiEndpointRequest,
+): Promise<{
+  success: boolean;
+  endpoint?: UserApiEndpointResponse;
+  error?: string;
+}> {
+  const testResult = await testEndpointConnection(
+    data.providerType,
+    data.endpointUrl,
+    data.apiKey,
+  );
+
+  if (!testResult.success) {
+    return { success: false, error: testResult.error };
+  }
+
+  const encrypted = encrypt(data.apiKey);
+
+  const endpoint = endpointRepository.create({
+    userId,
+    name: data.name,
+    providerType: data.providerType,
+    presetId: data.presetId,
+    endpointUrl: data.endpointUrl,
+    apiKeyEncrypted: encrypted.content,
+    apiKeyIv: encrypted.iv,
+    apiKeyLastFour: lastFour(data.apiKey),
+    modelId: data.modelId,
+    capabilities: data.capabilities,
+  });
+
+  await endpointRepository.save(endpoint);
+
+  return { success: true, endpoint: toResponse(endpoint) };
+}
+
+export async function update(
+  uuid: string,
+  userId: number,
+  data: UpdateUserApiEndpointRequest,
+): Promise<{
+  success: boolean;
+  endpoint?: UserApiEndpointResponse;
+  error?: string;
+}> {
+  const endpoint = await endpointRepository.findOne({
+    where: { uuid, userId },
+  });
+
+  if (!endpoint) {
+    return { success: false, error: "Endpoint not found" };
+  }
+
+  if (data.apiKey) {
+    const testResult = await testEndpointConnection(
+      endpoint.providerType,
+      data.endpointUrl ?? endpoint.endpointUrl,
+      data.apiKey,
+    );
+
+    if (!testResult.success) {
+      return { success: false, error: testResult.error };
+    }
+
+    const encrypted = encrypt(data.apiKey);
+    endpoint.apiKeyEncrypted = encrypted.content;
+    endpoint.apiKeyIv = encrypted.iv;
+    endpoint.apiKeyLastFour = lastFour(data.apiKey);
+  }
+
+  if (data.name !== undefined) endpoint.name = data.name;
+  if (data.endpointUrl !== undefined) endpoint.endpointUrl = data.endpointUrl;
+  if (data.modelId !== undefined) endpoint.modelId = data.modelId;
+  if (data.capabilities !== undefined)
+    endpoint.capabilities = data.capabilities;
+
+  await endpointRepository.save(endpoint);
+
+  return { success: true, endpoint: toResponse(endpoint) };
+}
+
+export async function remove(
+  uuid: string,
+  userId: number,
+): Promise<{ success: boolean; error?: string }> {
+  const endpoint = await endpointRepository.findOne({
+    where: { uuid, userId },
+  });
+
+  if (!endpoint) {
+    return { success: false, error: "Endpoint not found" };
+  }
+
+  await endpointRepository.delete({ id: endpoint.id });
+
+  return { success: true };
+}
+
+export async function test(
+  uuid: string,
+  userId: number,
+): Promise<{ success: boolean; error?: string }> {
+  const endpoint = await endpointRepository.findOne({
+    where: { uuid, userId },
+  });
+
+  if (!endpoint) {
+    return { success: false, error: "Endpoint not found" };
+  }
+
+  try {
+    const apiKey = decrypt({
+      iv: endpoint.apiKeyIv,
+      content: endpoint.apiKeyEncrypted,
+    });
+    return await testEndpointConnection(
+      endpoint.providerType,
+      endpoint.endpointUrl,
+      apiKey,
+    );
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    APP_LOGGER.error(`Failed to test endpoint ${uuid}: ${message}`);
+    return { success: false, error: message };
+  }
+}
+
+export async function decryptKey(
+  uuid: string,
+  userId: number,
+): Promise<string | null> {
+  const endpoint = await endpointRepository.findOne({
+    where: { uuid, userId },
+  });
+
+  if (!endpoint) {
+    return null;
+  }
+
+  try {
+    return decrypt({
+      iv: endpoint.apiKeyIv,
+      content: endpoint.apiKeyEncrypted,
+    });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    APP_LOGGER.error(`Failed to decrypt key for endpoint ${uuid}: ${message}`);
+    return null;
+  }
+}

--- a/src/types/user-api-endpoint.types.ts
+++ b/src/types/user-api-endpoint.types.ts
@@ -1,0 +1,38 @@
+export type EndpointProviderType = "openai" | "fal";
+
+export interface EndpointCapabilities {
+  textToImage: boolean;
+  imageToImage: boolean;
+  sizes: string[];
+}
+
+export interface CreateUserApiEndpointRequest {
+  name: string;
+  providerType: EndpointProviderType;
+  presetId: string;
+  endpointUrl: string;
+  apiKey: string;
+  modelId: string;
+  capabilities: EndpointCapabilities;
+}
+
+export interface UpdateUserApiEndpointRequest {
+  name?: string;
+  endpointUrl?: string;
+  apiKey?: string;
+  modelId?: string;
+  capabilities?: EndpointCapabilities;
+}
+
+export interface UserApiEndpointResponse {
+  uuid: string;
+  name: string;
+  providerType: EndpointProviderType;
+  presetId: string;
+  endpointUrl: string;
+  apiKeyLastFour: string;
+  modelId: string;
+  capabilities: EndpointCapabilities;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/src/utils/dream.util.ts
+++ b/src/utils/dream.util.ts
@@ -29,54 +29,68 @@ export const processDreamRequest = async (
 ) => {
   // Check for user endpoint prompts BEFORE parsePromptJson (which requires infinidream_algorithm)
   if (dream.prompt) {
+    // Only the JSON.parse may legitimately throw on a non-JSON prompt; keep the
+    // try/catch narrow so queue/resolve failures surface instead of being
+    // swallowed as "could not parse".
+    let rawPrompt: Record<string, unknown> | undefined;
     try {
-      const rawPrompt =
+      rawPrompt =
         typeof dream.prompt === "string"
           ? JSON.parse(dream.prompt)
-          : dream.prompt;
-
-      if (rawPrompt.userEndpointUuid) {
-        const userId = dream.user.id;
-        const apiKey = await userApiEndpointService.decryptKey(
-          rawPrompt.userEndpointUuid,
-          userId,
-        );
-
-        if (!apiKey) {
-          APP_LOGGER.error(
-            `User endpoint ${rawPrompt.userEndpointUuid} not found or key decryption failed for dream ${dream.uuid}`,
-          );
-          return { status: "failed", isPromptBased: true };
-        }
-
-        const jobData = {
-          dream_uuid: dream.uuid,
-          user_id: userId,
-          auto_upload: true,
-          previous_dream_status: previousStatus,
-          api_key: apiKey,
-          ...rawPrompt,
-        };
-
-        const result = await queueWorkerJob(USER_ENDPOINT_QUEUE, jobData);
-
-        if (result.success) {
-          APP_LOGGER.info(
-            `Queued dream ${dream.uuid} to user-endpoint queue via endpoint ${rawPrompt.userEndpointUuid}`,
-          );
-          return { id: result.jobId, status: "queued", isPromptBased: true };
-        } else {
-          APP_LOGGER.error(
-            `Failed to queue user-endpoint job for dream ${dream.uuid}: ${result.error}`,
-          );
-          return { status: "failed", isPromptBased: true };
-        }
-      }
-    } catch (err) {
-      // Not valid JSON or missing field — fall through to standard processing
+          : (dream.prompt as Record<string, unknown>);
+    } catch {
+      // Not valid JSON — fall through to standard processing
       APP_LOGGER.warn(
         `Could not parse raw prompt for user endpoint check on dream ${dream.uuid}`,
       );
+    }
+
+    if (rawPrompt && rawPrompt.userEndpointUuid) {
+      const userId = dream.user.id;
+      const userEndpointUuid = rawPrompt.userEndpointUuid as string;
+      const resolved = await userApiEndpointService.resolveEndpointForJob(
+        userEndpointUuid,
+        userId,
+      );
+
+      if (!resolved) {
+        APP_LOGGER.error(
+          `User endpoint ${userEndpointUuid} not found or key decryption failed for dream ${dream.uuid}`,
+        );
+        return { status: "failed", isPromptBased: true };
+      }
+
+      // Emit the exact job contract the worker's user-endpoint handler reads.
+      // Map prompt fields explicitly — do NOT spread rawPrompt, which would
+      // leak userEndpointUuid/infinidream_algorithm and drift field names.
+      const jobData = {
+        dream_uuid: dream.uuid,
+        user_id: userId,
+        auto_upload: true,
+        previous_dream_status: previousStatus,
+        userEndpointDecryptedKey: resolved.decryptedKey,
+        userEndpointUrl: resolved.endpointUrl,
+        userEndpointProvider: resolved.providerType,
+        userEndpointModelId: resolved.modelId,
+        prompt: rawPrompt.prompt as string,
+        image: rawPrompt.image as string | undefined,
+        size: rawPrompt.size as string | undefined,
+        n: rawPrompt.n as number | undefined,
+      };
+
+      const result = await queueWorkerJob(USER_ENDPOINT_QUEUE, jobData);
+
+      if (result.success) {
+        APP_LOGGER.info(
+          `Queued dream ${dream.uuid} to user-endpoint queue via endpoint ${userEndpointUuid}`,
+        );
+        return { id: result.jobId, status: "queued", isPromptBased: true };
+      } else {
+        APP_LOGGER.error(
+          `Failed to queue user-endpoint job for dream ${dream.uuid}: ${result.error}`,
+        );
+        return { status: "failed", isPromptBased: true };
+      }
     }
   }
 

--- a/src/utils/dream.util.ts
+++ b/src/utils/dream.util.ts
@@ -13,8 +13,10 @@ import {
   getAlgorithmFromPrompt,
   isValidAlgorithm,
   mapAlgorithmToQueue,
+  USER_ENDPOINT_QUEUE,
 } from "./prompt.util";
 import { queueWorkerJob, queueVideoIngestJob } from "./worker-queue.util";
+import * as userApiEndpointService from "services/user-api-endpoint.service";
 
 const dreamRepository = appDataSource.getRepository(Dream);
 const feedRepository = appDataSource.getRepository(FeedItem);
@@ -25,6 +27,59 @@ export const processDreamRequest = async (
   dream: Dream,
   previousStatus?: string,
 ) => {
+  // Check for user endpoint prompts BEFORE parsePromptJson (which requires infinidream_algorithm)
+  if (dream.prompt) {
+    try {
+      const rawPrompt =
+        typeof dream.prompt === "string"
+          ? JSON.parse(dream.prompt)
+          : dream.prompt;
+
+      if (rawPrompt.userEndpointUuid) {
+        const userId = dream.user.id;
+        const apiKey = await userApiEndpointService.decryptKey(
+          rawPrompt.userEndpointUuid,
+          userId,
+        );
+
+        if (!apiKey) {
+          APP_LOGGER.error(
+            `User endpoint ${rawPrompt.userEndpointUuid} not found or key decryption failed for dream ${dream.uuid}`,
+          );
+          return { status: "failed", isPromptBased: true };
+        }
+
+        const jobData = {
+          dream_uuid: dream.uuid,
+          user_id: userId,
+          auto_upload: true,
+          previous_dream_status: previousStatus,
+          api_key: apiKey,
+          ...rawPrompt,
+        };
+
+        const result = await queueWorkerJob(USER_ENDPOINT_QUEUE, jobData);
+
+        if (result.success) {
+          APP_LOGGER.info(
+            `Queued dream ${dream.uuid} to user-endpoint queue via endpoint ${rawPrompt.userEndpointUuid}`,
+          );
+          return { id: result.jobId, status: "queued", isPromptBased: true };
+        } else {
+          APP_LOGGER.error(
+            `Failed to queue user-endpoint job for dream ${dream.uuid}: ${result.error}`,
+          );
+          return { status: "failed", isPromptBased: true };
+        }
+      }
+    } catch (err) {
+      // Not valid JSON or missing field — fall through to standard processing
+      APP_LOGGER.warn(
+        `Could not parse raw prompt for user endpoint check on dream ${dream.uuid}`,
+      );
+    }
+  }
+
   const promptJson = parsePromptJson(dream);
 
   if (promptJson) {

--- a/src/utils/prompt.util.ts
+++ b/src/utils/prompt.util.ts
@@ -20,6 +20,8 @@ const SUPPORTED_ALGORITHMS = [
 ] as const;
 type SupportedAlgorithm = (typeof SUPPORTED_ALGORITHMS)[number];
 
+export const USER_ENDPOINT_QUEUE = "user-endpoint";
+
 const ALGORITHM_TO_QUEUE_MAP: Record<SupportedAlgorithm, string> = {
   animatediff: "video",
   deforum: "deforumvideo",

--- a/src/utils/url-safety.util.ts
+++ b/src/utils/url-safety.util.ts
@@ -9,7 +9,16 @@ import dns from "dns";
  * link-local, or otherwise internal address — blocking internal-network and
  * cloud-metadata (169.254.169.254) probing while preserving public custom
  * endpoints.
+ *
+ * The function returns the validated address(es) so callers can pin the
+ * connection to the exact IP that was checked, closing the DNS-rebinding
+ * TOCTOU window (see assertSafeExternalUrl).
  */
+
+export interface SafeAddress {
+  address: string;
+  family: number;
+}
 
 /**
  * Returns true if the given IPv4 string is loopback, private (RFC1918),
@@ -17,7 +26,10 @@ import dns from "dns";
  */
 function isBlockedIPv4(ip: string): boolean {
   const parts = ip.split(".").map((p) => Number(p));
-  if (parts.length !== 4 || parts.some((p) => Number.isNaN(p))) {
+  if (
+    parts.length !== 4 ||
+    parts.some((p) => Number.isNaN(p) || p < 0 || p > 255)
+  ) {
     // Not a parseable IPv4 — be conservative and block.
     return true;
   }
@@ -34,33 +46,125 @@ function isBlockedIPv4(ip: string): boolean {
 }
 
 /**
- * Returns true if the given IPv6 string is loopback, unspecified, unique-local
- * (fc00::/7), or link-local (fe80::/10). Also handles IPv4-mapped IPv6.
+ * Expands an IPv6 address to its full 8-group, 4-hex-digit form (lowercase).
+ * Handles "::" compression and a trailing dotted-quad (IPv4-mapped) suffix.
+ * Returns null if the address cannot be parsed as IPv6.
  */
-function isBlockedIPv6(ip: string): boolean {
-  const normalized = ip.toLowerCase();
+function expandIPv6(ip: string): string[] | null {
+  let work = ip.toLowerCase().trim();
 
-  if (normalized === "::1") return true; // loopback
-  if (normalized === "::") return true; // unspecified
-
-  // IPv4-mapped IPv6 (e.g. ::ffff:127.0.0.1) — validate the embedded IPv4.
-  const mapped = normalized.match(/::ffff:(\d+\.\d+\.\d+\.\d+)$/);
-  if (mapped) {
-    return isBlockedIPv4(mapped[1]);
+  // Strip zone id (e.g. fe80::1%eth0) — not relevant to the address itself.
+  const zoneIdx = work.indexOf("%");
+  if (zoneIdx !== -1) {
+    work = work.slice(0, zoneIdx);
   }
 
-  // Unique-local fc00::/7 (fc.. or fd..)
-  if (normalized.startsWith("fc") || normalized.startsWith("fd")) return true;
+  if (work.length === 0) return null;
 
-  // Link-local fe80::/10
+  // A trailing dotted-quad (e.g. ::ffff:127.0.0.1) is converted to two hex
+  // groups so the whole address can be treated uniformly as 8 16-bit groups.
+  const dottedMatch = work.match(/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+  if (dottedMatch) {
+    const octets = dottedMatch[1].split(".").map((p) => Number(p));
+    if (octets.some((o) => Number.isNaN(o) || o < 0 || o > 255)) {
+      return null;
+    }
+    const [o1, o2, o3, o4] = octets;
+    const g1 = ((o1 << 8) | o2).toString(16);
+    const g2 = ((o3 << 8) | o4).toString(16);
+    work = work.slice(0, dottedMatch.index) + `${g1}:${g2}`;
+  }
+
+  // Split on the "::" compression marker (at most one allowed).
+  const halves = work.split("::");
+  if (halves.length > 2) return null;
+
+  const head = halves[0].length ? halves[0].split(":") : [];
+  const tail =
+    halves.length === 2 && halves[1].length ? halves[1].split(":") : [];
+
+  let groups: string[];
+  if (halves.length === 2) {
+    // "::" present — fill the gap with enough zero groups to reach 8.
+    const missing = 8 - (head.length + tail.length);
+    if (missing < 0) return null;
+    groups = [...head, ...Array(missing).fill("0"), ...tail];
+  } else {
+    groups = head;
+  }
+
+  if (groups.length !== 8) return null;
+
+  // Validate and normalize each group to 4 hex digits.
+  const normalized: string[] = [];
+  for (const g of groups) {
+    if (!/^[0-9a-f]{1,4}$/.test(g)) return null;
+    normalized.push(g.padStart(4, "0"));
+  }
+  return normalized;
+}
+
+/**
+ * Returns true if the given IPv6 string is loopback, unspecified, unique-local
+ * (fc00::/7), link-local (fe80::/10), an IPv4-mapped IPv6 address whose
+ * embedded IPv4 is blocked, or a NAT64 well-known/local-use prefix.
+ *
+ * Both the dotted form (::ffff:127.0.0.1) and the hex form (::ffff:7f00:1) of
+ * IPv4-mapped addresses are handled by expanding to canonical groups first.
+ */
+function isBlockedIPv6(ip: string): boolean {
+  const groups = expandIPv6(ip);
+  if (groups === null) {
+    // Unparseable IPv6 — be conservative and block.
+    return true;
+  }
+
+  const numeric = groups.map((g) => parseInt(g, 16));
+
+  const isAllZero = (from: number, to: number): boolean => {
+    for (let i = from; i <= to; i++) {
+      if (numeric[i] !== 0) return false;
+    }
+    return true;
+  };
+
+  // ::1 loopback
+  if (isAllZero(0, 6) && numeric[7] === 1) return true;
+  // :: unspecified
+  if (isAllZero(0, 7)) return true;
+
+  // IPv4-mapped IPv6 ::ffff:0:0/96 — groups 0-4 are zero, group 5 is ffff.
+  // The embedded IPv4 lives in the low 32 bits (groups 6 and 7). This covers
+  // BOTH ::ffff:127.0.0.1 and the equivalent hex form ::ffff:7f00:1.
+  if (isAllZero(0, 4) && numeric[5] === 0xffff) {
+    const a = numeric[6] >> 8;
+    const b = numeric[6] & 0xff;
+    const c = numeric[7] >> 8;
+    const d = numeric[7] & 0xff;
+    return isBlockedIPv4(`${a}.${b}.${c}.${d}`);
+  }
+
+  // NAT64 well-known prefix 64:ff9b::/96 — an attacker could embed a private
+  // IPv4 in the low 32 bits and have a NAT64 gateway translate it internally.
   if (
-    normalized.startsWith("fe8") ||
-    normalized.startsWith("fe9") ||
-    normalized.startsWith("fea") ||
-    normalized.startsWith("feb")
+    numeric[0] === 0x64 &&
+    numeric[1] === 0xff9b &&
+    isAllZero(2, 5)
   ) {
     return true;
   }
+
+  // NAT64 local-use prefix 64:ff9b:1::/48 (RFC 8215).
+  if (numeric[0] === 0x64 && numeric[1] === 0xff9b && numeric[2] === 1) {
+    return true;
+  }
+
+  // Unique-local fc00::/7 — high 7 bits of the first byte are 1111110,
+  // i.e. first group in 0xfc00..0xfdff.
+  if (numeric[0] >= 0xfc00 && numeric[0] <= 0xfdff) return true;
+
+  // Link-local fe80::/10 — first group in 0xfe80..0xfebf.
+  if (numeric[0] >= 0xfe80 && numeric[0] <= 0xfebf) return true;
 
   return false;
 }
@@ -73,9 +177,19 @@ function isBlockedAddress(address: string, family: number): boolean {
  * Validates that a user-supplied URL is safe to make a server-side request to.
  * Throws an Error with a clear message if the URL is rejected.
  *
+ * Returns the validated resolved addresses. Callers that perform the outbound
+ * request should pin the connection to one of these addresses (e.g. via a
+ * custom https.Agent lookup) so that axios cannot independently re-resolve the
+ * hostname to a different (internal) address at request time — closing the
+ * DNS-rebinding TOCTOU window. Callers that only need the throw-on-unsafe
+ * behavior (create/update validation) may ignore the return value.
+ *
  * @param rawUrl the user-supplied URL string
+ * @returns the resolved, validated addresses (non-empty)
  */
-export async function assertSafeExternalUrl(rawUrl: string): Promise<void> {
+export async function assertSafeExternalUrl(
+  rawUrl: string,
+): Promise<SafeAddress[]> {
   let parsed: URL;
   try {
     parsed = new URL(rawUrl);
@@ -95,7 +209,7 @@ export async function assertSafeExternalUrl(rawUrl: string): Promise<void> {
   }
 
   // Resolve the hostname to ALL addresses and ensure none are internal.
-  let addresses: { address: string; family: number }[];
+  let addresses: SafeAddress[];
   try {
     addresses = await dns.promises.lookup(hostname, { all: true });
   } catch {
@@ -113,4 +227,6 @@ export async function assertSafeExternalUrl(rawUrl: string): Promise<void> {
       );
     }
   }
+
+  return addresses;
 }

--- a/src/utils/url-safety.util.ts
+++ b/src/utils/url-safety.util.ts
@@ -1,4 +1,5 @@
 import dns from "dns";
+import net from "net";
 
 /**
  * SSRF protection for user-supplied endpoint URLs.
@@ -201,11 +202,32 @@ export async function assertSafeExternalUrl(
     throw new Error("Endpoint URL must use https");
   }
 
-  const hostname = parsed.hostname.toLowerCase();
+  // For IPv6 literals the WHATWG URL parser keeps the surrounding brackets
+  // (e.g. "[::1]", "[2606:4700:4700::1111]"). Strip them so the bare address is
+  // usable for both net.isIP() and dns.lookup().
+  let hostname = parsed.hostname.toLowerCase();
+  if (hostname.startsWith("[") && hostname.endsWith("]")) {
+    hostname = hostname.slice(1, -1);
+  }
 
-  // Reject internal-only TLDs outright.
+  // Reject internal-only TLDs outright (operates on the de-bracketed host).
   if (hostname.endsWith(".internal") || hostname.endsWith(".local")) {
     throw new Error(`Endpoint URL host is not allowed: ${hostname}`);
+  }
+
+  // Short-circuit IP literals BEFORE any DNS lookup. This (a) fixes the
+  // regression where a public IPv6 literal was sent to dns.lookup with brackets
+  // intact → ENOTFOUND → wrongly rejected, (b) makes isBlockedIPv6 actually
+  // reachable for direct IPv6-literal URLs, and (c) closes a literal-path
+  // TOCTOU since the address validated is exactly the address connected to.
+  const literalFamily = net.isIP(hostname); // 4, 6, or 0 (not an IP literal)
+  if (literalFamily !== 0) {
+    if (isBlockedAddress(hostname, literalFamily)) {
+      throw new Error(
+        `Endpoint URL resolves to a private/internal address: ${hostname}`,
+      );
+    }
+    return [{ address: hostname, family: literalFamily }];
   }
 
   // Resolve the hostname to ALL addresses and ensure none are internal.

--- a/src/utils/url-safety.util.ts
+++ b/src/utils/url-safety.util.ts
@@ -1,0 +1,116 @@
+import dns from "dns";
+
+/**
+ * SSRF protection for user-supplied endpoint URLs.
+ *
+ * User endpoints may be arbitrary public URLs (the "Custom OpenAI-Compatible"
+ * option), so we cannot use a hard allowlist. Instead we require https, resolve
+ * the hostname, and reject any URL that resolves to a loopback, private,
+ * link-local, or otherwise internal address — blocking internal-network and
+ * cloud-metadata (169.254.169.254) probing while preserving public custom
+ * endpoints.
+ */
+
+/**
+ * Returns true if the given IPv4 string is loopback, private (RFC1918),
+ * link-local, or the unspecified address.
+ */
+function isBlockedIPv4(ip: string): boolean {
+  const parts = ip.split(".").map((p) => Number(p));
+  if (parts.length !== 4 || parts.some((p) => Number.isNaN(p))) {
+    // Not a parseable IPv4 — be conservative and block.
+    return true;
+  }
+  const [a, b] = parts;
+
+  if (a === 0) return true; // 0.0.0.0/8 (incl. 0.0.0.0)
+  if (a === 127) return true; // 127.0.0.0/8 loopback
+  if (a === 10) return true; // 10.0.0.0/8 private
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12 private
+  if (a === 192 && b === 168) return true; // 192.168.0.0/16 private
+  if (a === 169 && b === 254) return true; // 169.254.0.0/16 link-local (metadata)
+
+  return false;
+}
+
+/**
+ * Returns true if the given IPv6 string is loopback, unspecified, unique-local
+ * (fc00::/7), or link-local (fe80::/10). Also handles IPv4-mapped IPv6.
+ */
+function isBlockedIPv6(ip: string): boolean {
+  const normalized = ip.toLowerCase();
+
+  if (normalized === "::1") return true; // loopback
+  if (normalized === "::") return true; // unspecified
+
+  // IPv4-mapped IPv6 (e.g. ::ffff:127.0.0.1) — validate the embedded IPv4.
+  const mapped = normalized.match(/::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (mapped) {
+    return isBlockedIPv4(mapped[1]);
+  }
+
+  // Unique-local fc00::/7 (fc.. or fd..)
+  if (normalized.startsWith("fc") || normalized.startsWith("fd")) return true;
+
+  // Link-local fe80::/10
+  if (
+    normalized.startsWith("fe8") ||
+    normalized.startsWith("fe9") ||
+    normalized.startsWith("fea") ||
+    normalized.startsWith("feb")
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+function isBlockedAddress(address: string, family: number): boolean {
+  return family === 6 ? isBlockedIPv6(address) : isBlockedIPv4(address);
+}
+
+/**
+ * Validates that a user-supplied URL is safe to make a server-side request to.
+ * Throws an Error with a clear message if the URL is rejected.
+ *
+ * @param rawUrl the user-supplied URL string
+ */
+export async function assertSafeExternalUrl(rawUrl: string): Promise<void> {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new Error(`Invalid endpoint URL: ${rawUrl}`);
+  }
+
+  if (parsed.protocol !== "https:") {
+    throw new Error("Endpoint URL must use https");
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+
+  // Reject internal-only TLDs outright.
+  if (hostname.endsWith(".internal") || hostname.endsWith(".local")) {
+    throw new Error(`Endpoint URL host is not allowed: ${hostname}`);
+  }
+
+  // Resolve the hostname to ALL addresses and ensure none are internal.
+  let addresses: { address: string; family: number }[];
+  try {
+    addresses = await dns.promises.lookup(hostname, { all: true });
+  } catch {
+    throw new Error(`Could not resolve endpoint URL host: ${hostname}`);
+  }
+
+  if (addresses.length === 0) {
+    throw new Error(`Could not resolve endpoint URL host: ${hostname}`);
+  }
+
+  for (const { address, family } of addresses) {
+    if (isBlockedAddress(address, family)) {
+      throw new Error(
+        `Endpoint URL resolves to a disallowed address: ${hostname}`,
+      );
+    }
+  }
+}

--- a/src/utils/worker-queue.util.ts
+++ b/src/utils/worker-queue.util.ts
@@ -5,7 +5,9 @@ import { APP_LOGGER } from "shared/logger";
 interface JobData {
   dream_uuid: string;
   auto_upload?: boolean;
-  infinidream_algorithm: string;
+  // Optional: algorithm-based queues set this, but the user-endpoint queue
+  // routes by provider instead and has no infinidream_algorithm.
+  infinidream_algorithm?: string;
   previous_dream_status?: string;
   [key: string]: unknown;
 }


### PR DESCRIPTION
## Phase 1: API Key Config & i2i Variations — Backend

Lets users bring their own image-generation API endpoints (OpenAI / FAL) and use them from the studio, with encrypted-at-rest keys and validation on save.

### What's in this PR
- **`UserApiEndpoint` entity + migration** — per-user endpoints with AES-256 encrypted API key (random per-row IV), `apiKeyLastFour`, provider type, URL, modelId, typed capabilities, soft-delete + FK CASCADE to user.
- **Endpoint tester service** — validates OpenAI/FAL key + endpoint on save and via a `/test` route.
- **CRUD service** — encryption at rest; only `apiKeyLastFour` ever leaves the server; all queries scoped to the authenticated user (IDOR-safe).
- **Controller + routes** `/v1/user/api-endpoints` (list/create/update/delete/test), registered **before** `/v1/user` to avoid route shadowing; Joi validation on all mutating routes.
- **Dream-creation queue routing** — dreams referencing a user endpoint are resolved (URL/provider/modelId + decrypted key) and routed to the dedicated `user-endpoint` worker queue with the exact job-data contract the worker consumes.

### Security
- API keys encrypted at rest (env-sourced `CIPHER_KEY`), never logged, never returned.
- **SSRF guard** (`url-safety.util.ts`): https-only, DNS-resolves and rejects loopback / RFC1918 / link-local+metadata / IPv6 ULA / NAT64 / IPv4-mapped-IPv6 (both dotted and hex forms); IPv6 literals validated directly. Called at save-time and before every outbound tester request.
- **DNS-rebinding TOCTOU** closed by pinning the validated IP into the request (`https.Agent` lookup) with `maxRedirects: 0`, SNI preserved.
- 31 unit tests cover the SSRF classification table + the pinned-lookup contract.

### Cross-repo dependency
This is **1 of 3** PRs for the feature and is not functional end-to-end alone:
- worker: adapters + `user-endpoint` queue consumer
- frontend: account-page endpoint management + studio model picker / i2i

Job-data contract is verified key-by-key against the worker side. Merge the three together.

### Verification
`pnpm run build` ✓ · `pnpm run test:unit` (90 tests) ✓ · lint ✓

Plan & design: `docs/superpowers/plans/2026-06-12-api-key-config-i2i-variations.md` (metarepo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
